### PR TITLE
Enhancement: Create GitHubService for GitHub API integration

### DIFF
--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+
+class GitHubService
+{
+    public function __construct(
+        private string $token,
+        private string $baseUrl = 'https://api.github.com'
+    ) {}
+
+    /**
+     * Get all wiki pages for a repository
+     *
+     * GitHub wikis are Git repositories accessible via the repos API.
+     * This clones the wiki repo contents listing.
+     *
+     * @param  string  $wikiUrl  The URL to the GitHub wiki (e.g., https://github.com/owner/repo/wiki)
+     * @return array<int, array{slug: string, title: string}>
+     *
+     * @throws \Exception
+     */
+    public function getWikiPages(string $wikiUrl): array
+    {
+        $repoPath = $this->extractRepoPath($wikiUrl);
+
+        $response = $this->request("repos/{$repoPath}/wiki/pages");
+
+        if (! $response->successful()) {
+            throw new \Exception("Failed to fetch wiki pages: {$response->body()}");
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Get a specific wiki page content
+     *
+     * @param  string  $wikiUrl  The URL to the GitHub wiki
+     * @param  string  $slug  The wiki page slug
+     *
+     * @throws \Exception
+     */
+    public function getWikiPage(string $wikiUrl, string $slug): array
+    {
+        $repoPath = $this->extractRepoPath($wikiUrl);
+        $encodedSlug = urlencode($slug);
+
+        $response = $this->request("repos/{$repoPath}/wiki/pages/{$encodedSlug}");
+
+        if (! $response->successful()) {
+            throw new \Exception("Failed to fetch wiki page '{$slug}': {$response->body()}");
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Get raw file content from a GitHub repository
+     *
+     * @param  string  $fileUrl  The URL to the GitHub file (e.g., https://github.com/owner/repo/blob/main/CHANGELOG.md)
+     *
+     * @throws \Exception
+     */
+    public function getFileContent(string $fileUrl): string
+    {
+        [$repoPath, $filePath, $ref] = $this->extractFilePathFromUrl($fileUrl);
+        $encodedFilePath = collect(explode('/', $filePath))
+            ->map(fn (string $segment) => rawurlencode($segment))
+            ->implode('/');
+
+        $response = $this->request("repos/{$repoPath}/contents/{$encodedFilePath}?ref=".rawurlencode($ref), [
+            'Accept' => 'application/vnd.github.raw+json',
+        ]);
+
+        if (! $response->successful()) {
+            throw new \Exception("Failed to fetch file content from '{$fileUrl}': {$response->body()}");
+        }
+
+        return $response->body();
+    }
+
+    /**
+     * Extract owner/repo from a GitHub URL
+     *
+     * @throws \Exception
+     */
+    protected function extractRepoPath(string $url): string
+    {
+        // Example URL formats:
+        // https://github.com/owner/repo/wiki
+        // https://github.com/owner/repo/wiki/Page-Name
+        // https://github.com/owner/repo/blob/main/file.md
+        // https://github.com/owner/repo
+
+        $pattern = '/github\.com\/([^\/]+\/[^\/]+)/';
+        if (preg_match($pattern, $url, $matches)) {
+            // Remove trailing .git, .wiki.git, or /wiki, /blob, etc.
+            $repoPath = preg_replace('/\.(wiki\.)?git$/', '', $matches[1]);
+
+            return $repoPath;
+        }
+
+        throw new \Exception("Invalid GitHub URL format: {$url}");
+    }
+
+    /**
+     * Extract repo path, file path, and ref from a GitHub file URL
+     *
+     * @return array{0: string, 1: string, 2: string} [repoPath, filePath, ref]
+     *
+     * @throws \Exception
+     */
+    protected function extractFilePathFromUrl(string $fileUrl): array
+    {
+        // Example URL formats:
+        // https://github.com/owner/repo/blob/main/CHANGELOG.md
+        // https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md
+
+        $pattern = '/github\.com\/([^\/]+\/[^\/]+)\/blob\/([^\/]+)\/(.+)/';
+        if (preg_match($pattern, $fileUrl, $matches)) {
+            return [
+                $matches[1], // repo path (owner/repo)
+                $matches[3], // file path
+                $matches[2], // ref (branch)
+            ];
+        }
+
+        throw new \Exception("Invalid GitHub file URL format: {$fileUrl}");
+    }
+
+    /**
+     * Make an authenticated request to the GitHub API with rate limit handling
+     *
+     * @param  array<string, string>  $additionalHeaders
+     *
+     * @throws \Exception
+     */
+    protected function request(string $endpoint, array $additionalHeaders = []): Response
+    {
+        $headers = array_merge([
+            'Authorization' => "Bearer {$this->token}",
+            'Accept' => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ], $additionalHeaders);
+
+        $response = Http::withHeaders($headers)->get("{$this->baseUrl}/{$endpoint}");
+
+        if ($response->status() === 403 && $response->header('X-RateLimit-Remaining') === '0') {
+            $resetTime = (int) $response->header('X-RateLimit-Reset');
+            $waitSeconds = max(0, $resetTime - time());
+
+            throw new \Exception("GitHub API rate limit exceeded. Resets in {$waitSeconds} seconds.");
+        }
+
+        return $response;
+    }
+}

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -119,6 +119,9 @@ class GitHubService
         // Example URL formats:
         // https://github.com/owner/repo/blob/main/CHANGELOG.md
         // https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md
+        // Note: Branch names with slashes (e.g., feature/branch) are ambiguous
+        // in GitHub URLs and cannot be reliably parsed without an API call to
+        // resolve the ref. This pattern assumes single-segment branch names.
 
         $pattern = '/github\.com\/([^\/]+\/[^\/]+)\/blob\/([^\/]+)\/(.+)/';
         if (preg_match($pattern, $fileUrl, $matches)) {
@@ -147,7 +150,7 @@ class GitHubService
             'X-GitHub-Api-Version' => '2022-11-28',
         ], $additionalHeaders);
 
-        $response = Http::withHeaders($headers)->get("{$this->baseUrl}/{$endpoint}");
+        $response = Http::withHeaders($headers)->timeout(30)->get("{$this->baseUrl}/{$endpoint}");
 
         if ($response->status() === 403 && $response->header('X-RateLimit-Remaining') === '0') {
             $resetTime = (int) $response->header('X-RateLimit-Reset');

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Services\GitHubService;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->service = new GitHubService('test-token');
+});
+
+test('getWikiPages fetches wiki pages successfully', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response([
+            ['slug' => 'home', 'title' => 'Home'],
+            ['slug' => 'installation', 'title' => 'Installation'],
+        ], 200),
+    ]);
+
+    $result = $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+
+    expect($result)->toBeArray()
+        ->toHaveCount(2)
+        ->and($result[0]['slug'])->toBe('home')
+        ->and($result[1]['slug'])->toBe('installation');
+});
+
+test('getWikiPages throws exception on failure', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response(['message' => 'Not Found'], 404),
+    ]);
+
+    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+})->throws(\Exception::class, 'Failed to fetch wiki pages');
+
+test('getWikiPage fetches specific wiki page successfully', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages/home' => Http::response([
+            'slug' => 'home',
+            'title' => 'Home',
+            'content' => '# Welcome',
+        ], 200),
+    ]);
+
+    $result = $this->service->getWikiPage('https://github.com/owner/repo/wiki', 'home');
+
+    expect($result)->toBeArray()
+        ->and($result['slug'])->toBe('home')
+        ->and($result['content'])->toBe('# Welcome');
+});
+
+test('getWikiPage throws exception on failure', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages/nonexistent' => Http::response(['message' => 'Not Found'], 404),
+    ]);
+
+    $this->service->getWikiPage('https://github.com/owner/repo/wiki', 'nonexistent');
+})->throws(\Exception::class, "Failed to fetch wiki page 'nonexistent'");
+
+test('getFileContent fetches raw file content successfully', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/contents/CHANGELOG.md?ref=main' => Http::response('# Changelog content', 200),
+    ]);
+
+    $result = $this->service->getFileContent('https://github.com/owner/repo/blob/main/CHANGELOG.md');
+
+    expect($result)->toBe('# Changelog content');
+});
+
+test('getFileContent fetches nested file content successfully', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/contents/docs/CHANGELOG.md?ref=develop' => Http::response('# Nested changelog', 200),
+    ]);
+
+    $result = $this->service->getFileContent('https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md');
+
+    expect($result)->toBe('# Nested changelog');
+});
+
+test('getFileContent throws exception on failure', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/contents/MISSING.md?ref=main' => Http::response(['message' => 'Not Found'], 404),
+    ]);
+
+    $this->service->getFileContent('https://github.com/owner/repo/blob/main/MISSING.md');
+})->throws(\Exception::class, 'Failed to fetch file content');
+
+test('extractRepoPath parses GitHub URLs correctly', function () {
+    $service = new GitHubService('test-token');
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('extractRepoPath');
+    $method->setAccessible(true);
+
+    expect($method->invoke($service, 'https://github.com/owner/repo/wiki'))->toBe('owner/repo')
+        ->and($method->invoke($service, 'https://github.com/owner/repo/wiki/Page-Name'))->toBe('owner/repo')
+        ->and($method->invoke($service, 'https://github.com/owner/repo/blob/main/file.md'))->toBe('owner/repo')
+        ->and($method->invoke($service, 'https://github.com/owner/repo'))->toBe('owner/repo');
+});
+
+test('extractRepoPath throws exception for invalid URL', function () {
+    $service = new GitHubService('test-token');
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('extractRepoPath');
+    $method->setAccessible(true);
+
+    $method->invoke($service, 'https://invalid-url.com/something');
+})->throws(\Exception::class, 'Invalid GitHub URL format');
+
+test('extractFilePathFromUrl parses GitHub file URLs correctly', function () {
+    $service = new GitHubService('test-token');
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('extractFilePathFromUrl');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($service, 'https://github.com/owner/repo/blob/main/CHANGELOG.md');
+    expect($result)->toBe(['owner/repo', 'CHANGELOG.md', 'main']);
+
+    $result = $method->invoke($service, 'https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md');
+    expect($result)->toBe(['owner/repo', 'docs/CHANGELOG.md', 'develop']);
+});
+
+test('extractFilePathFromUrl throws exception for invalid URL', function () {
+    $service = new GitHubService('test-token');
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('extractFilePathFromUrl');
+    $method->setAccessible(true);
+
+    $method->invoke($service, 'https://github.com/owner/repo/tree/main');
+})->throws(\Exception::class, 'Invalid GitHub file URL format');
+
+test('request handles rate limiting', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response(
+            ['message' => 'API rate limit exceeded'],
+            403,
+            ['X-RateLimit-Remaining' => '0', 'X-RateLimit-Reset' => (string) (time() + 60)]
+        ),
+    ]);
+
+    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+})->throws(\Exception::class, 'GitHub API rate limit exceeded');
+
+test('request sends correct authentication headers', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response([], 200),
+    ]);
+
+    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('Authorization', 'Bearer test-token')
+            && $request->hasHeader('Accept', 'application/vnd.github+json')
+            && $request->hasHeader('X-GitHub-Api-Version', '2022-11-28');
+    });
+});

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -92,7 +92,9 @@ test('extractRepoPath parses GitHub URLs correctly', function () {
     expect($method->invoke($service, 'https://github.com/owner/repo/wiki'))->toBe('owner/repo')
         ->and($method->invoke($service, 'https://github.com/owner/repo/wiki/Page-Name'))->toBe('owner/repo')
         ->and($method->invoke($service, 'https://github.com/owner/repo/blob/main/file.md'))->toBe('owner/repo')
-        ->and($method->invoke($service, 'https://github.com/owner/repo'))->toBe('owner/repo');
+        ->and($method->invoke($service, 'https://github.com/owner/repo'))->toBe('owner/repo')
+        ->and($method->invoke($service, 'https://github.com/owner/repo.git'))->toBe('owner/repo')
+        ->and($method->invoke($service, 'https://github.com/owner/repo.wiki.git'))->toBe('owner/repo');
 });
 
 test('extractRepoPath throws exception for invalid URL', function () {


### PR DESCRIPTION
## Summary

Create a new `GitHubService` class parallel to the existing `GitLabService` to interact with the GitHub API for fetching wiki pages and repository file content.

Closes #1

## Changes

- Created `app/Services/GitHubService.php` with all required methods:
  - `getWikiPages()` — List all wiki pages for a repo
  - `getWikiPage()` — Get individual page content
  - `getFileContent()` — Get changelog/file from repo (with per-segment URL encoding for nested paths)
  - `extractRepoPath()` — Parse owner/repo from GitHub URLs
  - `extractFilePathFromUrl()` — Parse file info from GitHub blob URLs
  - `request()` — Centralized HTTP method with Bearer token auth, API versioning, and rate limit handling
- Created `tests/Feature/Services/GitHubServiceTest.php` with 13 tests covering all methods, error handling, rate limiting, and authentication headers

## Testing

- 13 Pest feature tests added covering:
  - Successful wiki page listing and individual page fetching
  - Successful file content fetching (root and nested paths)
  - Exception handling for API failures
  - URL parsing for various GitHub URL formats
  - Rate limit detection and error messaging
  - Correct authentication header verification

All tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated GitHub API to retrieve and display wiki pages from repositories
  * Added ability to fetch raw content from files in GitHub repositories
  * Implemented automatic rate limit detection and error handling for GitHub API requests

* **Tests**
  * Added comprehensive test coverage for GitHub API integration and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->