### PR TITLE
enhancement: add GitHub token to application settings

### DIFF
--- a/Modules/Admin/app/Livewire/SettingsPage.php
+++ b/Modules/Admin/app/Livewire/SettingsPage.php
@@ -16,6 +16,8 @@ class SettingsPage extends Component
 
     public ?string $gitLabToken = '';
 
+    public ?string $gitHubToken = '';
+
     public ?string $homePage = '';
 
     public ?string $googleAnalyticsId = '';
@@ -28,6 +30,10 @@ class SettingsPage extends Component
         $encryptedToken = $settings->firstWhere('key', 'gitlab_token')?->value;
         $this->gitLabToken = $encryptedToken ? decrypt($encryptedToken) : '';
 
+        // Decrypt the GitHub token when retrieving it
+        $encryptedGitHubToken = $settings->firstWhere('key', 'github_token')?->value;
+        $this->gitHubToken = $encryptedGitHubToken ? decrypt($encryptedGitHubToken) : '';
+
         $this->homePage = $settings->firstWhere('key', 'homePage')?->value ?? '';
         $this->googleAnalyticsId = $settings->firstWhere('key', 'google_analytics_id')?->value ?? '';
     }
@@ -36,9 +42,11 @@ class SettingsPage extends Component
     {
         $validated = $this->validate([
             'gitLabToken' => 'nullable|string',
+            'gitHubToken' => ['nullable', 'string', 'regex:/^(ghp_|github_pat_)[a-zA-Z0-9_]+$/'],
             'homePage' => 'nullable|string',
             'googleAnalyticsId' => 'nullable|string|regex:/^G-[A-Z0-9]+$/',
         ], [
+            'gitHubToken.regex' => 'The GitHub token must be a valid personal access token (starts with ghp_ or github_pat_).',
             'googleAnalyticsId.regex' => 'The Google Analytics ID must be in the format G-XXXXXXXXXX',
         ]);
 
@@ -51,6 +59,16 @@ class SettingsPage extends Component
             Setting::updateOrCreate(
                 ['key' => 'gitlab_token'],
                 ['value' => $tokenValue]
+            );
+
+            // Encrypt the GitHub token before storing it for security
+            $gitHubTokenValue = ! empty($validated['gitHubToken'])
+                ? encrypt($validated['gitHubToken'])
+                : null;
+
+            Setting::updateOrCreate(
+                ['key' => 'github_token'],
+                ['value' => $gitHubTokenValue]
             );
 
             Setting::updateOrCreate(

--- a/Modules/Admin/app/Livewire/SettingsPage.php
+++ b/Modules/Admin/app/Livewire/SettingsPage.php
@@ -3,6 +3,7 @@
 namespace Modules\Admin\Livewire;
 
 use ArtisanPack\LivewireUiComponents\Traits\Toast;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -26,13 +27,19 @@ class SettingsPage extends Component
     {
         $settings = Setting::get();
 
-        // Decrypt the GitLab token when retrieving it
         $encryptedToken = $settings->firstWhere('key', 'gitlab_token')?->value;
-        $this->gitLabToken = $encryptedToken ? decrypt($encryptedToken) : '';
+        try {
+            $this->gitLabToken = $encryptedToken ? decrypt($encryptedToken) : '';
+        } catch (DecryptException) {
+            $this->gitLabToken = '';
+        }
 
-        // Decrypt the GitHub token when retrieving it
         $encryptedGitHubToken = $settings->firstWhere('key', 'github_token')?->value;
-        $this->gitHubToken = $encryptedGitHubToken ? decrypt($encryptedGitHubToken) : '';
+        try {
+            $this->gitHubToken = $encryptedGitHubToken ? decrypt($encryptedGitHubToken) : '';
+        } catch (DecryptException) {
+            $this->gitHubToken = '';
+        }
 
         $this->homePage = $settings->firstWhere('key', 'homePage')?->value ?? '';
         $this->googleAnalyticsId = $settings->firstWhere('key', 'google_analytics_id')?->value ?? '';
@@ -51,7 +58,6 @@ class SettingsPage extends Component
         ]);
 
         if ($validated) {
-            // Encrypt the GitLab token before storing it for security
             $tokenValue = ! empty($validated['gitLabToken'])
                 ? encrypt($validated['gitLabToken'])
                 : null;
@@ -61,7 +67,6 @@ class SettingsPage extends Component
                 ['value' => $tokenValue]
             );
 
-            // Encrypt the GitHub token before storing it for security
             $gitHubTokenValue = ! empty($validated['gitHubToken'])
                 ? encrypt($validated['gitHubToken'])
                 : null;

--- a/Modules/Admin/resources/views/livewire/settings-page.blade.php
+++ b/Modules/Admin/resources/views/livewire/settings-page.blade.php
@@ -13,6 +13,8 @@
                 <div class="space-y-4">
                     <x-artisanpack-input wire:model="gitLabToken" label="GitLab Token" type="password" />
 
+                    <x-artisanpack-input wire:model="gitHubToken" label="GitHub Token" type="password" hint="A GitHub personal access token (PAT) with the repo scope. Create one at GitHub → Settings → Developer settings → Personal access tokens." />
+
                     <x-artisanpack-input wire:model="googleAnalyticsId" label="Google Analytics ID" placeholder="G-XXXXXXXXXX" hint="Your GA4 Measurement ID (e.g., G-ABC123XYZ)" />
                 </div>
             </x-artisanpack-card>

--- a/tests/Feature/Livewire/Admin/SettingsPageTest.php
+++ b/tests/Feature/Livewire/Admin/SettingsPageTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Modules\Admin\Livewire\SettingsPage;
+use Modules\Core\Setting;
+
+uses(RefreshDatabase::class);
+
+test('it mounts with empty values when no settings exist', function () {
+    Livewire::test(SettingsPage::class)
+        ->assertSet('gitLabToken', '')
+        ->assertSet('gitHubToken', '')
+        ->assertSet('homePage', '')
+        ->assertSet('googleAnalyticsId', '');
+});
+
+test('it mounts with decrypted github token when setting exists', function () {
+    Setting::create([
+        'key' => 'github_token',
+        'value' => encrypt('ghp_testtoken123'),
+    ]);
+
+    Livewire::test(SettingsPage::class)
+        ->assertSet('gitHubToken', 'ghp_testtoken123');
+});
+
+test('it saves github token encrypted', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitHubToken', 'ghp_testtoken123')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $setting = Setting::where('key', 'github_token')->first();
+    expect($setting)->not->toBeNull();
+    expect(decrypt($setting->value))->toBe('ghp_testtoken123');
+});
+
+test('it saves github pat token with github_pat_ prefix', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitHubToken', 'github_pat_abc123XYZ')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $setting = Setting::where('key', 'github_token')->first();
+    expect($setting)->not->toBeNull();
+    expect(decrypt($setting->value))->toBe('github_pat_abc123XYZ');
+});
+
+test('it saves null when github token is empty', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitHubToken', '')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $setting = Setting::where('key', 'github_token')->first();
+    expect($setting->value)->toBeNull();
+});
+
+test('it validates github token format', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitHubToken', 'invalid-token-format')
+        ->call('save')
+        ->assertHasErrors(['gitHubToken' => 'regex']);
+});
+
+test('it saves gitlab token encrypted', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitLabToken', 'glpat-testtoken123')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $setting = Setting::where('key', 'gitlab_token')->first();
+    expect($setting)->not->toBeNull();
+    expect(decrypt($setting->value))->toBe('glpat-testtoken123');
+});
+
+test('it saves all settings together', function () {
+    Livewire::test(SettingsPage::class)
+        ->set('gitLabToken', 'glpat-testtoken')
+        ->set('gitHubToken', 'ghp_testtoken')
+        ->set('googleAnalyticsId', 'G-ABC123XYZ')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(Setting::where('key', 'gitlab_token')->first())->not->toBeNull();
+    expect(Setting::where('key', 'github_token')->first())->not->toBeNull();
+    expect(Setting::where('key', 'google_analytics_id')->first()->value)->toBe('G-ABC123XYZ');
+});

--- a/tests/Feature/Livewire/Admin/SettingsPageTest.php
+++ b/tests/Feature/Livewire/Admin/SettingsPageTest.php
@@ -25,27 +25,19 @@ test('it mounts with decrypted github token when setting exists', function () {
         ->assertSet('gitHubToken', 'ghp_testtoken123');
 });
 
-test('it saves github token encrypted', function () {
+test('it saves github token encrypted', function (string $token) {
     Livewire::test(SettingsPage::class)
-        ->set('gitHubToken', 'ghp_testtoken123')
+        ->set('gitHubToken', $token)
         ->call('save')
         ->assertHasNoErrors();
 
     $setting = Setting::where('key', 'github_token')->first();
     expect($setting)->not->toBeNull();
-    expect(decrypt($setting->value))->toBe('ghp_testtoken123');
-});
-
-test('it saves github pat token with github_pat_ prefix', function () {
-    Livewire::test(SettingsPage::class)
-        ->set('gitHubToken', 'github_pat_abc123XYZ')
-        ->call('save')
-        ->assertHasNoErrors();
-
-    $setting = Setting::where('key', 'github_token')->first();
-    expect($setting)->not->toBeNull();
-    expect(decrypt($setting->value))->toBe('github_pat_abc123XYZ');
-});
+    expect(decrypt($setting->value))->toBe($token);
+})->with([
+    'classic token' => 'ghp_testtoken123',
+    'fine-grained token' => 'github_pat_abc123XYZ',
+]);
 
 test('it saves null when github token is empty', function () {
     Livewire::test(SettingsPage::class)


### PR DESCRIPTION
## Summary

Add an encrypted `github_token` setting to the application settings page, matching the existing `gitlab_token` pattern. This enables GitHub API integration for importing documentation and changelogs from GitHub repositories.

Closes #2

## Changes

- Added `gitHubToken` property to `SettingsPage` Livewire component with encrypt/decrypt handling
- Added GitHub Token password input field to the settings form with help text explaining PAT setup and required `repo` scope
- Added validation ensuring tokens start with `ghp_` or `github_pat_`
- Both `gitlab_token` and `github_token` are retained during the transition period

## Testing

- 8 new feature tests covering:
  - Mount with empty/existing values
  - Save with encryption for both `ghp_` and `github_pat_` prefixes
  - Save with empty value (null storage)
  - Token format validation
  - Saving all settings together
- Manual testing confirmed on the settings page

All tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub token configuration to Admin Integrations with a dedicated input and creation hint.
  * Tokens are encrypted before storage; empty GitHub input is saved as null.

* **Bug Fixes**
  * Improved handling of token decryption failures to avoid errors on load.

* **Tests**
  * Added tests covering mount, validation, encryption, persistence, and empty-token behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->