### PR TITLE
enhancement: update ImportWikiDocumentation job for GitHub

### DIFF
--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -77,8 +77,11 @@ class EditPackage extends Component
 
         $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
 
-        // Decrypt the token (it's stored encrypted for security)
-        $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
+        try {
+            $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
+        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+            $githubToken = null;
+        }
 
         if (empty($githubToken)) {
             $this->error('GitHub token not configured in settings.');
@@ -86,7 +89,7 @@ class EditPackage extends Component
             return;
         }
 
-        ImportWikiDocumentation::dispatch($this->package, $githubToken);
+        ImportWikiDocumentation::dispatch($this->package);
 
         $this->success('Documentation import started! This may take a few moments.');
     }

--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -75,18 +75,18 @@ class EditPackage extends Component
             return;
         }
 
-        $encryptedToken = Setting::where('key', 'gitlab_token')->first()?->value;
+        $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
 
         // Decrypt the token (it's stored encrypted for security)
-        $gitlabToken = $encryptedToken ? decrypt($encryptedToken) : null;
+        $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
 
-        if (empty($gitlabToken)) {
-            $this->error('GitLab token not configured in settings.');
+        if (empty($githubToken)) {
+            $this->error('GitHub token not configured in settings.');
 
             return;
         }
 
-        ImportWikiDocumentation::dispatch($this->package, $gitlabToken);
+        ImportWikiDocumentation::dispatch($this->package, $githubToken);
 
         $this->success('Documentation import started! This may take a few moments.');
     }

--- a/app/Jobs/ImportWikiDocumentation.php
+++ b/app/Jobs/ImportWikiDocumentation.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Services\GitLabService;
+use App\Services\GitHubService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
@@ -26,7 +26,7 @@ class ImportWikiDocumentation implements ShouldQueue
      */
     public function __construct(
         public Package $package,
-        public string $gitlabToken
+        public string $githubToken
     ) {}
 
     /**
@@ -35,10 +35,10 @@ class ImportWikiDocumentation implements ShouldQueue
     public function handle(): void
     {
         try {
-            $gitlabService = new GitLabService($this->gitlabToken);
+            $githubService = app()->make(GitHubService::class, ['token' => $this->githubToken]);
 
-            // Get all wiki pages
-            $wikiPages = $gitlabService->getWikiPages($this->package->wiki_url);
+            // Get all wiki pages with content in a single clone operation
+            $wikiPages = $githubService->getWikiPagesWithContent($this->package->wiki_url);
 
             Log::info('Found {count} wiki pages for package {package}', [
                 'count' => count($wikiPages),
@@ -46,10 +46,7 @@ class ImportWikiDocumentation implements ShouldQueue
             ]);
 
             foreach ($wikiPages as $wikiPage) {
-                // Get full content for each page
-                $fullPage = $gitlabService->getWikiPage($this->package->wiki_url, $wikiPage['slug']);
-
-                $content = $fullPage['content'] ?? '';
+                $content = $wikiPage['content'] ?? '';
 
                 // Extract title from YAML front matter and remove it
                 $yamlTitle = $this->extractTitleFromYaml($content);
@@ -62,9 +59,9 @@ class ImportWikiDocumentation implements ShouldQueue
                 // Clean and update links
                 $cleanedContent = $this->updateInternalLinks($content);
 
-                // Title priority: YAML > H1 > Title case GitLab title > slug
-                $gitlabTitle = $fullPage['title'] ?? $wikiPage['title'] ?? null;
-                $title = $yamlTitle ?? $h1Title ?? ($gitlabTitle ? $this->toTitleCase($gitlabTitle) : $wikiPage['slug']);
+                // Title priority: YAML > H1 > Title case GitHub title > slug
+                $githubTitle = $wikiPage['title'] ?? null;
+                $title = $yamlTitle ?? $h1Title ?? ($githubTitle ? $this->toTitleCase($githubTitle) : $wikiPage['slug']);
 
                 // Generate meta description from content
                 $metaDescription = $this->generateMetaDescription($cleanedContent);

--- a/app/Jobs/ImportWikiDocumentation.php
+++ b/app/Jobs/ImportWikiDocumentation.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Setting;
 use Modules\Packages\Documentation;
 use Modules\Packages\Package;
 
@@ -25,8 +26,7 @@ class ImportWikiDocumentation implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public Package $package,
-        public string $githubToken
+        public Package $package
     ) {}
 
     /**
@@ -35,7 +35,19 @@ class ImportWikiDocumentation implements ShouldQueue
     public function handle(): void
     {
         try {
-            $githubService = app()->make(GitHubService::class, ['token' => $this->githubToken]);
+            $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
+
+            try {
+                $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
+            } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                $githubToken = null;
+            }
+
+            if (empty($githubToken)) {
+                throw new \Exception('GitHub token not configured or could not be decrypted');
+            }
+
+            $githubService = app()->make(GitHubService::class, ['token' => $githubToken]);
 
             // Get all wiki pages with content in a single clone operation
             $wikiPages = $githubService->getWikiPagesWithContent($this->package->wiki_url);
@@ -175,11 +187,29 @@ class ImportWikiDocumentation implements ShouldQueue
      */
     protected function updateInternalLinks(string $content): string
     {
-        // Get the site URL
         $siteUrl = rtrim(config('app.url'), '/');
 
-        // Pattern to match wiki links (both relative and absolute)
-        // This will match links like: [text](page-slug) or [text](parent/page-slug)
+        // Extract the wiki base URL from the package wiki_url for absolute link matching
+        // e.g., https://github.com/owner/repo/wiki -> matches https://github.com/owner/repo/wiki/Page-Name
+        $wikiBase = rtrim($this->package->wiki_url, '/');
+        $escapedWikiBase = preg_quote($wikiBase, '/');
+
+        // First, rewrite absolute GitHub wiki URLs
+        $content = preg_replace_callback(
+            '/\[([^\]]+)\]\(('.preg_quote($wikiBase, '/').'\/([^)#?\s]+))([^)]*)\)/',
+            function ($matches) use ($siteUrl) {
+                $linkText = $matches[1];
+                $pageName = $matches[3];
+                $suffix = $matches[4]; // anchors, query strings
+
+                $newUrl = "{$siteUrl}/documentation/{$this->package->slug}/{$pageName}";
+
+                return "[{$linkText}]({$newUrl}{$suffix})";
+            },
+            $content
+        );
+
+        // Then, rewrite relative wiki links
         $pattern = '/\[([^\]]+)\]\((?!https?:\/\/)([^)]+)\)/';
 
         return preg_replace_callback($pattern, function ($matches) use ($siteUrl) {
@@ -190,7 +220,6 @@ class ImportWikiDocumentation implements ShouldQueue
             $path = ltrim($originalPath, '/');
             $path = preg_replace('/^(wikis?\/|\.\.?\/)/', '', $path);
 
-            // Build the new URL
             $newUrl = "{$siteUrl}/documentation/{$this->package->slug}/{$path}";
 
             return "[{$linkText}]({$newUrl})";

--- a/app/Jobs/ImportWikiDocumentation.php
+++ b/app/Jobs/ImportWikiDocumentation.php
@@ -196,7 +196,7 @@ class ImportWikiDocumentation implements ShouldQueue
 
         // First, rewrite absolute GitHub wiki URLs
         $content = preg_replace_callback(
-            '/\[([^\]]+)\]\(('.preg_quote($wikiBase, '/').'\/([^)#?\s]+))([^)]*)\)/',
+            '/\[([^\]]+)\]\(('.$escapedWikiBase.'\/([^)#?\s]+))([^)]*)\)/',
             function ($matches) use ($siteUrl) {
                 $linkText = $matches[1];
                 $pageName = $matches[3];

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -32,9 +32,13 @@ class GitHubService
             $pages = $this->parseWikiDirectory($clonePath);
 
             return array_map(function (array $page) use ($clonePath) {
-                $pageData = $this->readWikiPage($clonePath, $page['slug']);
+                $pageData = $this->readWikiPage($clonePath, $page['file']);
 
-                return array_merge($page, ['content' => $pageData['content']]);
+                return [
+                    'slug' => $page['slug'],
+                    'title' => $page['title'],
+                    'content' => $pageData['content'],
+                ];
             }, $pages);
         } finally {
             $this->removeDirectory($clonePath);
@@ -77,7 +81,7 @@ class GitHubService
     protected function cloneWikiRepo(string $wikiUrl): string
     {
         $repoPath = $this->extractRepoPath($wikiUrl);
-        $clonePath = sys_get_temp_dir().'/wiki-'.md5($repoPath.time());
+        $clonePath = sys_get_temp_dir().'/wiki-'.bin2hex(random_bytes(8));
         $cloneUrl = "https://github.com/{$repoPath}.wiki.git";
 
         // Create a temporary GIT_ASKPASS script that echoes the token
@@ -103,12 +107,49 @@ class GitHubService
                 throw new \Exception('Failed to start git clone process');
             }
 
-            $stderr = stream_get_contents($pipes[2]);
+            // Enforce a 120-second timeout on the clone
+            $timeoutSeconds = 120;
+            $startTime = time();
+            $timedOut = false;
+
+            // Set stderr to non-blocking so we can poll
+            stream_set_blocking($pipes[2], false);
+            stream_set_blocking($pipes[1], false);
+
+            $stderr = '';
+            while (true) {
+                $status = proc_get_status($process);
+                if (! $status['running']) {
+                    // Process finished — read remaining stderr
+                    $stderr .= stream_get_contents($pipes[2]);
+
+                    break;
+                }
+
+                if ((time() - $startTime) >= $timeoutSeconds) {
+                    $timedOut = true;
+                    proc_terminate($process, 9);
+
+                    break;
+                }
+
+                $stderr .= stream_get_contents($pipes[2]);
+                usleep(100_000); // 100ms
+            }
+
             fclose($pipes[1]);
             fclose($pipes[2]);
             $exitCode = proc_close($process);
 
+            if ($timedOut) {
+                $this->removeDirectory($clonePath);
+
+                throw new \Exception("Git clone timed out after {$timeoutSeconds} seconds for '{$repoPath}'");
+            }
+
             if ($exitCode !== 0) {
+                $this->removeDirectory($clonePath);
+
                 // Redact any token-like strings from stderr before throwing
                 $sanitizedStderr = preg_replace('/gh[pousr]_[A-Za-z0-9]+/', '[REDACTED]', $stderr);
 
@@ -124,7 +165,7 @@ class GitHubService
     /**
      * Parse all markdown files in the cloned wiki directory
      *
-     * @return array<int, array{slug: string, title: string}>
+     * @return array<int, array{slug: string, title: string, file: string}>
      */
     protected function parseWikiDirectory(string $clonePath): array
     {
@@ -134,7 +175,7 @@ class GitHubService
         );
 
         foreach ($iterator as $file) {
-            if ($file->getExtension() !== 'md') {
+            if (strtolower($file->getExtension()) !== 'md') {
                 continue;
             }
 
@@ -145,8 +186,8 @@ class GitHubService
                 continue;
             }
 
-            // Convert filename to slug (remove .md extension)
-            $slug = preg_replace('/\.md$/', '', $relativePath);
+            // Convert filename to slug (remove .md/.MD extension, case-insensitive)
+            $slug = preg_replace('/\.md$/i', '', $relativePath);
 
             // Convert filename to title (replace hyphens with spaces)
             $title = str_replace('-', ' ', basename($slug));
@@ -154,6 +195,7 @@ class GitHubService
             $pages[] = [
                 'slug' => $slug,
                 'title' => $title,
+                'file' => $relativePath,
             ];
         }
 
@@ -163,32 +205,30 @@ class GitHubService
     /**
      * Read a specific wiki page from the cloned directory
      *
-     * @return array{slug: string, title: string, content: string}
+     * @param  string  $clonePath  The clone directory path
+     * @param  string  $relativeFile  The relative file path within the clone (e.g., "guides/usage.md")
+     * @return array{content: string}
      *
      * @throws \Exception
      */
-    protected function readWikiPage(string $clonePath, string $slug): array
+    protected function readWikiPage(string $clonePath, string $relativeFile): array
     {
-        $filePath = "{$clonePath}/{$slug}.md";
+        $filePath = "{$clonePath}/{$relativeFile}";
 
         $cloneReal = realpath($clonePath);
         $fileReal = realpath($filePath);
 
         if ($fileReal === false || $cloneReal === false || ! str_starts_with($fileReal, $cloneReal.DIRECTORY_SEPARATOR)) {
-            throw new \Exception("Wiki page '{$slug}' not found or path is outside repository");
+            throw new \Exception("Wiki page '{$relativeFile}' not found or path is outside repository");
         }
 
         $content = file_get_contents($fileReal);
 
         if ($content === false) {
-            throw new \Exception("Failed to read wiki page '{$slug}' at '{$fileReal}'");
+            throw new \Exception("Failed to read wiki page '{$relativeFile}' at '{$fileReal}'");
         }
 
-        $title = str_replace('-', ' ', basename($slug));
-
         return [
-            'slug' => $slug,
-            'title' => $title,
             'content' => $content,
         ];
     }

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -110,7 +110,7 @@ class GitHubService
 
             if ($exitCode !== 0) {
                 // Redact any token-like strings from stderr before throwing
-                $sanitizedStderr = preg_replace('/ghp_[A-Za-z0-9]+/', '[REDACTED]', $stderr);
+                $sanitizedStderr = preg_replace('/gh[pousr]_[A-Za-z0-9]+/', '[REDACTED]', $stderr);
 
                 throw new \Exception("Failed to clone wiki repository for '{$repoPath}': {$sanitizedStderr}");
             }
@@ -179,6 +179,11 @@ class GitHubService
         }
 
         $content = file_get_contents($fileReal);
+
+        if ($content === false) {
+            throw new \Exception("Failed to read wiki page '{$slug}' at '{$fileReal}'");
+        }
+
         $title = str_replace('-', ' ', basename($slug));
 
         return [

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -69,34 +69,56 @@ class GitHubService
     /**
      * Clone the wiki Git repository to a temporary directory
      *
+     * Uses GIT_ASKPASS to supply credentials securely instead of embedding
+     * the token in the clone URL.
+     *
      * @throws \Exception
      */
     protected function cloneWikiRepo(string $wikiUrl): string
     {
         $repoPath = $this->extractRepoPath($wikiUrl);
         $clonePath = sys_get_temp_dir().'/wiki-'.md5($repoPath.time());
-        $cloneUrl = "https://{$this->token}@github.com/{$repoPath}.wiki.git";
+        $cloneUrl = "https://github.com/{$repoPath}.wiki.git";
 
-        $process = proc_open(
-            ['git', 'clone', '--depth', '1', $cloneUrl, $clonePath],
-            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
-            $pipes
-        );
+        // Create a temporary GIT_ASKPASS script that echoes the token
+        $askpassScript = tempnam(sys_get_temp_dir(), 'git-askpass-');
+        file_put_contents($askpassScript, "#!/bin/sh\necho '{$this->token}'\n");
+        chmod($askpassScript, 0700);
 
-        if (! is_resource($process)) {
-            throw new \Exception('Failed to start git clone process');
+        try {
+            $env = [
+                'GIT_ASKPASS' => $askpassScript,
+                'GIT_TERMINAL_PROMPT' => '0',
+            ];
+
+            $process = proc_open(
+                ['git', 'clone', '--depth', '1', $cloneUrl, $clonePath],
+                [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+                $pipes,
+                null,
+                $env
+            );
+
+            if (! is_resource($process)) {
+                throw new \Exception('Failed to start git clone process');
+            }
+
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($process);
+
+            if ($exitCode !== 0) {
+                // Redact any token-like strings from stderr before throwing
+                $sanitizedStderr = preg_replace('/ghp_[A-Za-z0-9]+/', '[REDACTED]', $stderr);
+
+                throw new \Exception("Failed to clone wiki repository for '{$repoPath}': {$sanitizedStderr}");
+            }
+
+            return $clonePath;
+        } finally {
+            @unlink($askpassScript);
         }
-
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[1]);
-        fclose($pipes[2]);
-        $exitCode = proc_close($process);
-
-        if ($exitCode !== 0) {
-            throw new \Exception("Failed to clone wiki repository for '{$repoPath}': {$stderr}");
-        }
-
-        return $clonePath;
     }
 
     /**
@@ -149,11 +171,14 @@ class GitHubService
     {
         $filePath = "{$clonePath}/{$slug}.md";
 
-        if (! file_exists($filePath)) {
-            throw new \Exception("Wiki page '{$slug}' not found");
+        $cloneReal = realpath($clonePath);
+        $fileReal = realpath($filePath);
+
+        if ($fileReal === false || $cloneReal === false || ! str_starts_with($fileReal, $cloneReal.DIRECTORY_SEPARATOR)) {
+            throw new \Exception("Wiki page '{$slug}' not found or path is outside repository");
         }
 
-        $content = file_get_contents($filePath);
+        $content = file_get_contents($fileReal);
         $title = str_replace('-', ' ', basename($slug));
 
         return [

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -13,49 +13,32 @@ class GitHubService
     ) {}
 
     /**
-     * Get all wiki pages for a repository
+     * Get all wiki pages with their content by cloning the wiki Git repo once
      *
-     * GitHub wikis are Git repositories accessible via the repos API.
-     * This clones the wiki repo contents listing.
+     * GitHub wikis are separate Git repositories (repo.wiki.git) that are not
+     * accessible via the REST API. This clones the wiki repo to a temp directory,
+     * parses the markdown files, and returns all pages with content in a single operation.
      *
      * @param  string  $wikiUrl  The URL to the GitHub wiki (e.g., https://github.com/owner/repo/wiki)
-     * @return array<int, array{slug: string, title: string}>
+     * @return array<int, array{slug: string, title: string, content: string}>
      *
      * @throws \Exception
      */
-    public function getWikiPages(string $wikiUrl): array
+    public function getWikiPagesWithContent(string $wikiUrl): array
     {
-        $repoPath = $this->extractRepoPath($wikiUrl);
+        $clonePath = $this->cloneWikiRepo($wikiUrl);
 
-        $response = $this->request("repos/{$repoPath}/wiki/pages");
+        try {
+            $pages = $this->parseWikiDirectory($clonePath);
 
-        if (! $response->successful()) {
-            throw new \Exception("Failed to fetch wiki pages: {$response->body()}");
+            return array_map(function (array $page) use ($clonePath) {
+                $pageData = $this->readWikiPage($clonePath, $page['slug']);
+
+                return array_merge($page, ['content' => $pageData['content']]);
+            }, $pages);
+        } finally {
+            $this->removeDirectory($clonePath);
         }
-
-        return $response->json();
-    }
-
-    /**
-     * Get a specific wiki page content
-     *
-     * @param  string  $wikiUrl  The URL to the GitHub wiki
-     * @param  string  $slug  The wiki page slug
-     *
-     * @throws \Exception
-     */
-    public function getWikiPage(string $wikiUrl, string $slug): array
-    {
-        $repoPath = $this->extractRepoPath($wikiUrl);
-        $encodedSlug = urlencode($slug);
-
-        $response = $this->request("repos/{$repoPath}/wiki/pages/{$encodedSlug}");
-
-        if (! $response->successful()) {
-            throw new \Exception("Failed to fetch wiki page '{$slug}': {$response->body()}");
-        }
-
-        return $response->json();
     }
 
     /**
@@ -81,6 +64,128 @@ class GitHubService
         }
 
         return $response->body();
+    }
+
+    /**
+     * Clone the wiki Git repository to a temporary directory
+     *
+     * @throws \Exception
+     */
+    protected function cloneWikiRepo(string $wikiUrl): string
+    {
+        $repoPath = $this->extractRepoPath($wikiUrl);
+        $clonePath = sys_get_temp_dir().'/wiki-'.md5($repoPath.time());
+        $cloneUrl = "https://{$this->token}@github.com/{$repoPath}.wiki.git";
+
+        $process = proc_open(
+            ['git', 'clone', '--depth', '1', $cloneUrl, $clonePath],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+
+        if (! is_resource($process)) {
+            throw new \Exception('Failed to start git clone process');
+        }
+
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        if ($exitCode !== 0) {
+            throw new \Exception("Failed to clone wiki repository for '{$repoPath}': {$stderr}");
+        }
+
+        return $clonePath;
+    }
+
+    /**
+     * Parse all markdown files in the cloned wiki directory
+     *
+     * @return array<int, array{slug: string, title: string}>
+     */
+    protected function parseWikiDirectory(string $clonePath): array
+    {
+        $pages = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($clonePath, \RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'md') {
+                continue;
+            }
+
+            $relativePath = str_replace($clonePath.'/', '', $file->getPathname());
+
+            // Skip hidden files and the .git directory
+            if (str_starts_with($relativePath, '.')) {
+                continue;
+            }
+
+            // Convert filename to slug (remove .md extension)
+            $slug = preg_replace('/\.md$/', '', $relativePath);
+
+            // Convert filename to title (replace hyphens with spaces)
+            $title = str_replace('-', ' ', basename($slug));
+
+            $pages[] = [
+                'slug' => $slug,
+                'title' => $title,
+            ];
+        }
+
+        return $pages;
+    }
+
+    /**
+     * Read a specific wiki page from the cloned directory
+     *
+     * @return array{slug: string, title: string, content: string}
+     *
+     * @throws \Exception
+     */
+    protected function readWikiPage(string $clonePath, string $slug): array
+    {
+        $filePath = "{$clonePath}/{$slug}.md";
+
+        if (! file_exists($filePath)) {
+            throw new \Exception("Wiki page '{$slug}' not found");
+        }
+
+        $content = file_get_contents($filePath);
+        $title = str_replace('-', ' ', basename($slug));
+
+        return [
+            'slug' => $slug,
+            'title' => $title,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * Recursively remove a directory
+     */
+    protected function removeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
     }
 
     /**

--- a/tests/Feature/Jobs/ImportWikiDocumentationTest.php
+++ b/tests/Feature/Jobs/ImportWikiDocumentationTest.php
@@ -1,13 +1,20 @@
 <?php
 
 use App\Jobs\ImportWikiDocumentation;
+use App\Services\GitHubService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Modules\Packages\Documentation;
 use Modules\Packages\Package;
 
 uses(RefreshDatabase::class);
+
+function mockWikiPages(array $pages): void
+{
+    $mock = Mockery::mock(GitHubService::class);
+    $mock->shouldReceive('getWikiPagesWithContent')->andReturn($pages);
+    app()->bind(GitHubService::class, fn () => $mock);
+}
 
 test('imports wiki documentation successfully', function () {
     Log::shouldReceive('info')->times(4);
@@ -15,24 +22,12 @@ test('imports wiki documentation successfully', function () {
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-            ['slug' => 'installation', 'title' => 'Installation'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Home',
-            'content' => "# Welcome to the Documentation\n\nSome content here.",
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/installation' => Http::response([
-            'slug' => 'installation',
-            'title' => 'Installation',
-            'content' => "# Installation Guide\n\nInstallation steps.",
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => "# Welcome to the Documentation\n\nSome content here."],
+        ['slug' => 'installation', 'title' => 'installation', 'content' => "# Installation Guide\n\nInstallation steps."],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -58,7 +53,7 @@ test('updates existing documentation when re-importing', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
     Documentation::create([
@@ -68,15 +63,8 @@ test('updates existing documentation when re-importing', function () {
         'package_id' => $package->id,
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Updated Title',
-            'content' => 'Updated content',
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'Updated Title', 'content' => 'Updated content'],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -94,12 +82,13 @@ test('logs error and throws exception on failure', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response(['error' => 'Not found'], 404),
-    ]);
+    $mock = Mockery::mock(GitHubService::class);
+    $mock->shouldReceive('getWikiPagesWithContent')
+        ->andThrow(new \Exception('Failed to clone wiki repository'));
+    app()->bind(GitHubService::class, fn () => $mock);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
     $job->handle();
@@ -111,18 +100,11 @@ test('extracts title from YAML front matter', function () {
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Home',
-            'content' => "---\ntitle: Custom Title\n---\n\n# Welcome to the Documentation\n\nContent here.",
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => "---\ntitle: Custom Title\n---\n\n# Welcome to the Documentation\n\nContent here."],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -137,28 +119,17 @@ test('extracts title from YAML front matter', function () {
 });
 
 test('sets parent relationships for subpages and keeps full slugs', function () {
+    Log::shouldReceive('info')->zeroOrMoreTimes();
+
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'guides', 'title' => 'Guides'],
-            ['slug' => 'guides/usage', 'title' => 'Usage'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/guides' => Http::response([
-            'slug' => 'guides',
-            'title' => 'Guides',
-            'content' => '# Guides Overview',
-        ], 200),
-        // URL encoded slug: guides/usage becomes guides%2Fusage
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/guides%2Fusage' => Http::response([
-            'slug' => 'guides/usage',
-            'title' => 'Usage',
-            'content' => '# How to use',
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'guides', 'title' => 'guides', 'content' => '# Guides Overview'],
+        ['slug' => 'guides/usage', 'title' => 'usage', 'content' => '# How to use'],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -184,18 +155,11 @@ test('updates internal documentation links', function () {
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Home',
-            'content' => 'Check out the [installation guide](installation) and [usage guide](guides/usage).',
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => 'Check out the [installation guide](installation) and [usage guide](guides/usage).'],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -213,18 +177,11 @@ test('extracts title from H1 header when no YAML front matter', function () {
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'GitLab Title'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'GitLab Title',
-            'content' => "# Welcome to the Documentation\n\nThis is the content.",
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => "# Welcome to the Documentation\n\nThis is the content."],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -236,24 +193,17 @@ test('extracts title from H1 header when no YAML front matter', function () {
         ->and($homeDoc->content)->toContain('This is the content.');
 });
 
-test('uses title case GitLab title when no YAML or H1 exists', function () {
+test('uses title case GitHub title when no YAML or H1 exists', function () {
     Log::shouldReceive('info')->times(3);
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'getting started with the package'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'getting started with the package',
-            'content' => 'This is the content without any headers.',
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'getting started with the package', 'content' => 'This is the content without any headers.'],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');
@@ -270,18 +220,11 @@ test('YAML title takes precedence over H1 header', function () {
     $package = Package::factory()->create([
         'name' => 'Test Package',
         'slug' => 'test-package',
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-        ], 200),
-        'https://gitlab.com/api/v4/projects/group%2Fproject/wikis/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Home',
-            'content' => "---\ntitle: YAML Title\n---\n\n# H1 Title\n\nContent here.",
-        ], 200),
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => "---\ntitle: YAML Title\n---\n\n# H1 Title\n\nContent here."],
     ]);
 
     $job = new ImportWikiDocumentation($package, 'test-token');

--- a/tests/Feature/Jobs/ImportWikiDocumentationTest.php
+++ b/tests/Feature/Jobs/ImportWikiDocumentationTest.php
@@ -4,10 +4,18 @@ use App\Jobs\ImportWikiDocumentation;
 use App\Services\GitHubService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Setting;
 use Modules\Packages\Documentation;
 use Modules\Packages\Package;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Setting::create([
+        'key' => 'github_token',
+        'value' => encrypt('test-token'),
+    ]);
+});
 
 function mockWikiPages(array $pages): void
 {
@@ -30,7 +38,7 @@ test('imports wiki documentation successfully', function () {
         ['slug' => 'installation', 'title' => 'installation', 'content' => "# Installation Guide\n\nInstallation steps."],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     expect(Documentation::count())->toBe(2);
@@ -67,7 +75,7 @@ test('updates existing documentation when re-importing', function () {
         ['slug' => 'home', 'title' => 'Updated Title', 'content' => 'Updated content'],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     expect(Documentation::count())->toBe(1);
@@ -90,9 +98,23 @@ test('logs error and throws exception on failure', function () {
         ->andThrow(new \Exception('Failed to clone wiki repository'));
     app()->bind(GitHubService::class, fn () => $mock);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 })->throws(\Exception::class);
+
+test('throws exception when github token is not configured', function () {
+    Log::shouldReceive('error')->once();
+
+    Setting::where('key', 'github_token')->delete();
+
+    $package = Package::factory()->create([
+        'name' => 'Test Package',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
+    ]);
+
+    $job = new ImportWikiDocumentation($package);
+    $job->handle();
+})->throws(\Exception::class, 'GitHub token not configured');
 
 test('extracts title from YAML front matter', function () {
     Log::shouldReceive('info')->times(3);
@@ -107,7 +129,7 @@ test('extracts title from YAML front matter', function () {
         ['slug' => 'home', 'title' => 'home', 'content' => "---\ntitle: Custom Title\n---\n\n# Welcome to the Documentation\n\nContent here."],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     $homeDoc = Documentation::where('slug', 'home')->first();
@@ -132,7 +154,7 @@ test('sets parent relationships for subpages and keeps full slugs', function () 
         ['slug' => 'guides/usage', 'title' => 'usage', 'content' => '# How to use'],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     expect(Documentation::count())->toBe(2);
@@ -141,7 +163,6 @@ test('sets parent relationships for subpages and keeps full slugs', function () 
     expect($parent)->not->toBeNull()
         ->and($parent->parent)->toBeNull();
 
-    // Child should keep full slug "guides/usage", not shortened to "usage"
     $child = Documentation::where('slug', 'guides/usage')->first();
     expect($child)->not->toBeNull()
         ->and($child->parent)->toBe($parent->id);
@@ -162,13 +183,38 @@ test('updates internal documentation links', function () {
         ['slug' => 'home', 'title' => 'home', 'content' => 'Check out the [installation guide](installation) and [usage guide](guides/usage).'],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     $homeDoc = Documentation::where('slug', 'home')->first();
     expect($homeDoc->content)
         ->toContain('https://example.com/documentation/test-package/installation')
         ->toContain('https://example.com/documentation/test-package/guides/usage');
+});
+
+test('rewrites absolute GitHub wiki URLs to internal links', function () {
+    Log::shouldReceive('info')->times(3);
+
+    config(['app.url' => 'https://example.com']);
+
+    $package = Package::factory()->create([
+        'name' => 'Test Package',
+        'slug' => 'test-package',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
+    ]);
+
+    mockWikiPages([
+        ['slug' => 'home', 'title' => 'home', 'content' => 'See [page](https://github.com/owner/repo/wiki/Getting-Started) and [other](https://github.com/owner/repo/wiki/API-Reference).'],
+    ]);
+
+    $job = new ImportWikiDocumentation($package);
+    $job->handle();
+
+    $homeDoc = Documentation::where('slug', 'home')->first();
+    expect($homeDoc->content)
+        ->toContain('https://example.com/documentation/test-package/Getting-Started')
+        ->toContain('https://example.com/documentation/test-package/API-Reference')
+        ->not->toContain('github.com');
 });
 
 test('extracts title from H1 header when no YAML front matter', function () {
@@ -184,7 +230,7 @@ test('extracts title from H1 header when no YAML front matter', function () {
         ['slug' => 'home', 'title' => 'home', 'content' => "# Welcome to the Documentation\n\nThis is the content."],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     $homeDoc = Documentation::where('slug', 'home')->first();
@@ -206,7 +252,7 @@ test('uses title case GitHub title when no YAML or H1 exists', function () {
         ['slug' => 'home', 'title' => 'getting started with the package', 'content' => 'This is the content without any headers.'],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     $homeDoc = Documentation::where('slug', 'home')->first();
@@ -227,7 +273,7 @@ test('YAML title takes precedence over H1 header', function () {
         ['slug' => 'home', 'title' => 'home', 'content' => "---\ntitle: YAML Title\n---\n\n# H1 Title\n\nContent here."],
     ]);
 
-    $job = new ImportWikiDocumentation($package, 'test-token');
+    $job = new ImportWikiDocumentation($package);
     $job->handle();
 
     $homeDoc = Documentation::where('slug', 'home')->first();

--- a/tests/Feature/Livewire/EditPackageTest.php
+++ b/tests/Feature/Livewire/EditPackageTest.php
@@ -28,7 +28,7 @@ test('import documentation dispatches job when wiki url and token are present', 
         ->assertHasNoErrors();
 
     Queue::assertPushed(ImportWikiDocumentation::class, function ($job) use ($package) {
-        return $job->package->id === $package->id && $job->githubToken === 'test-token-123';
+        return $job->package->id === $package->id;
     });
 });
 

--- a/tests/Feature/Livewire/EditPackageTest.php
+++ b/tests/Feature/Livewire/EditPackageTest.php
@@ -15,12 +15,12 @@ test('import documentation dispatches job when wiki url and token are present', 
     Queue::fake();
 
     $package = Package::factory()->create([
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
     Setting::create([
-        'key' => 'gitlab_token',
-        'value' => 'test-token-123',
+        'key' => 'github_token',
+        'value' => encrypt('test-token-123'),
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])
@@ -28,7 +28,7 @@ test('import documentation dispatches job when wiki url and token are present', 
         ->assertHasNoErrors();
 
     Queue::assertPushed(ImportWikiDocumentation::class, function ($job) use ($package) {
-        return $job->package->id === $package->id && $job->gitlabToken === 'test-token-123';
+        return $job->package->id === $package->id && $job->githubToken === 'test-token-123';
     });
 });
 
@@ -40,8 +40,8 @@ test('import documentation does not dispatch job when wiki url is missing', func
     ]);
 
     Setting::create([
-        'key' => 'gitlab_token',
-        'value' => 'test-token-123',
+        'key' => 'github_token',
+        'value' => encrypt('test-token-123'),
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])
@@ -51,11 +51,11 @@ test('import documentation does not dispatch job when wiki url is missing', func
     Queue::assertNothingPushed();
 });
 
-test('import documentation does not dispatch job when gitlab token is not configured', function () {
+test('import documentation does not dispatch job when github token is not configured', function () {
     Queue::fake();
 
     $package = Package::factory()->create([
-        'wiki_url' => 'https://gitlab.com/group/project/-/wikis',
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])
@@ -74,7 +74,7 @@ test('import changelog dispatches job when changelog url and token are present',
 
     Setting::create([
         'key' => 'gitlab_token',
-        'value' => 'test-token-123',
+        'value' => encrypt('test-token-123'),
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])
@@ -95,7 +95,7 @@ test('import changelog does not dispatch job when changelog url is missing', fun
 
     Setting::create([
         'key' => 'gitlab_token',
-        'value' => 'test-token-123',
+        'value' => encrypt('test-token-123'),
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -5,60 +5,27 @@ use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
     $this->service = new GitHubService('test-token');
+    $this->tempDir = null;
 });
 
-test('getWikiPagesWithContent clones wiki and returns pages with content', function () {
-    // Create a mock subclass that overrides cloneWikiRepo to use a temp directory
-    $tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
-    mkdir($tempDir, 0777, true);
-    file_put_contents("{$tempDir}/home.md", "# Welcome\n\nHome content.");
-    file_put_contents("{$tempDir}/installation.md", "# Installation\n\nInstall steps.");
+afterEach(function () {
+    if ($this->tempDir && is_dir($this->tempDir)) {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
 
-    $service = new class('test-token', $tempDir) extends GitHubService
-    {
-        private string $fakePath;
-
-        public function __construct(string $token, string $fakePath)
-        {
-            parent::__construct($token);
-            $this->fakePath = $fakePath;
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
         }
 
-        protected function cloneWikiRepo(string $wikiUrl): string
-        {
-            return $this->fakePath;
-        }
-
-        protected function removeDirectory(string $path): void
-        {
-            // Don't remove during test — we'll clean up manually
-        }
-    };
-
-    $result = $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
-
-    expect($result)->toBeArray()
-        ->toHaveCount(2);
-
-    $slugs = array_column($result, 'slug');
-    expect($slugs)->toContain('home')
-        ->toContain('installation');
-
-    $homePage = collect($result)->firstWhere('slug', 'home');
-    expect($homePage['content'])->toBe("# Welcome\n\nHome content.");
-
-    // Clean up
-    array_map('unlink', glob("{$tempDir}/*.md"));
-    rmdir($tempDir);
+        rmdir($this->tempDir);
+    }
 });
 
-test('getWikiPagesWithContent handles subdirectories', function () {
-    $tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
-    mkdir("{$tempDir}/guides", 0777, true);
-    file_put_contents("{$tempDir}/guides.md", '# Guides');
-    file_put_contents("{$tempDir}/guides/usage.md", '# Usage Guide');
-
-    $service = new class('test-token', $tempDir) extends GitHubService
+function createFakeWikiService(string $tempDir): GitHubService
+{
+    return new class('test-token', $tempDir) extends GitHubService
     {
         private string $fakePath;
 
@@ -75,7 +42,35 @@ test('getWikiPagesWithContent handles subdirectories', function () {
 
         protected function removeDirectory(string $path): void {}
     };
+}
 
+test('getWikiPagesWithContent clones wiki and returns pages with content', function () {
+    $this->tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
+    mkdir($this->tempDir, 0777, true);
+    file_put_contents("{$this->tempDir}/home.md", "# Welcome\n\nHome content.");
+    file_put_contents("{$this->tempDir}/installation.md", "# Installation\n\nInstall steps.");
+
+    $service = createFakeWikiService($this->tempDir);
+    $result = $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
+
+    expect($result)->toBeArray()
+        ->toHaveCount(2);
+
+    $slugs = array_column($result, 'slug');
+    expect($slugs)->toContain('home')
+        ->toContain('installation');
+
+    $homePage = collect($result)->firstWhere('slug', 'home');
+    expect($homePage['content'])->toBe("# Welcome\n\nHome content.");
+});
+
+test('getWikiPagesWithContent handles subdirectories', function () {
+    $this->tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
+    mkdir("{$this->tempDir}/guides", 0777, true);
+    file_put_contents("{$this->tempDir}/guides.md", '# Guides');
+    file_put_contents("{$this->tempDir}/guides/usage.md", '# Usage Guide');
+
+    $service = createFakeWikiService($this->tempDir);
     $result = $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
 
     $slugs = array_column($result, 'slug');
@@ -84,12 +79,6 @@ test('getWikiPagesWithContent handles subdirectories', function () {
 
     $childPage = collect($result)->firstWhere('slug', 'guides/usage');
     expect($childPage['content'])->toBe('# Usage Guide');
-
-    // Clean up
-    unlink("{$tempDir}/guides.md");
-    unlink("{$tempDir}/guides/usage.md");
-    rmdir("{$tempDir}/guides");
-    rmdir($tempDir);
 });
 
 test('getWikiPagesWithContent throws exception when clone fails', function () {

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -81,6 +81,29 @@ test('getWikiPagesWithContent handles subdirectories', function () {
     expect($childPage['content'])->toBe('# Usage Guide');
 });
 
+test('readWikiPage rejects symlinks pointing outside clone directory', function () {
+    $this->tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
+    mkdir($this->tempDir, 0777, true);
+
+    // Create a file outside the clone directory
+    $outsideDir = sys_get_temp_dir().'/test-wiki-outside-'.uniqid();
+    mkdir($outsideDir, 0777, true);
+    file_put_contents("{$outsideDir}/secret.md", 'SECRET DATA');
+
+    // Create a symlink inside the clone pointing to the outside file
+    symlink("{$outsideDir}/secret.md", "{$this->tempDir}/evil.md");
+
+    $service = createFakeWikiService($this->tempDir);
+
+    // The symlinked page resolves outside the clone — readWikiPage should throw
+    expect(fn () => $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki'))
+        ->toThrow(\Exception::class, 'not found or path is outside repository');
+
+    // Clean up outside dir
+    unlink("{$outsideDir}/secret.md");
+    rmdir($outsideDir);
+});
+
 test('getWikiPagesWithContent throws exception when clone fails', function () {
     $service = new class('test-token') extends GitHubService
     {
@@ -187,6 +210,7 @@ test('request sends correct authentication headers', function () {
 
     Http::assertSent(function ($request) {
         return $request->hasHeader('Authorization', 'Bearer test-token')
-            && $request->hasHeader('X-GitHub-Api-Version', '2022-11-28');
+            && $request->hasHeader('X-GitHub-Api-Version', '2022-11-28')
+            && $request->hasHeader('Accept', 'application/vnd.github.raw+json');
     });
 });

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -93,10 +93,15 @@ test('getWikiPagesWithContent handles subdirectories', function () {
 });
 
 test('getWikiPagesWithContent throws exception when clone fails', function () {
-    // Use a real service with a bad token — the clone should fail
-    $service = new GitHubService('invalid-token');
+    $service = new class('test-token') extends GitHubService
+    {
+        protected function cloneWikiRepo(string $wikiUrl): string
+        {
+            throw new \Exception("Failed to clone wiki repository for 'owner/repo': remote: Repository not found.");
+        }
+    };
 
-    $service->getWikiPagesWithContent('https://github.com/nonexistent-owner-xyz/nonexistent-repo-xyz/wiki');
+    $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
 })->throws(\Exception::class, 'Failed to clone wiki repository');
 
 test('getFileContent fetches raw file content successfully', function () {

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -7,53 +7,97 @@ beforeEach(function () {
     $this->service = new GitHubService('test-token');
 });
 
-test('getWikiPages fetches wiki pages successfully', function () {
-    Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response([
-            ['slug' => 'home', 'title' => 'Home'],
-            ['slug' => 'installation', 'title' => 'Installation'],
-        ], 200),
-    ]);
+test('getWikiPagesWithContent clones wiki and returns pages with content', function () {
+    // Create a mock subclass that overrides cloneWikiRepo to use a temp directory
+    $tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
+    mkdir($tempDir, 0777, true);
+    file_put_contents("{$tempDir}/home.md", "# Welcome\n\nHome content.");
+    file_put_contents("{$tempDir}/installation.md", "# Installation\n\nInstall steps.");
 
-    $result = $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+    $service = new class('test-token', $tempDir) extends GitHubService
+    {
+        private string $fakePath;
 
-    expect($result)->toBeArray()
-        ->toHaveCount(2)
-        ->and($result[0]['slug'])->toBe('home')
-        ->and($result[1]['slug'])->toBe('installation');
-});
+        public function __construct(string $token, string $fakePath)
+        {
+            parent::__construct($token);
+            $this->fakePath = $fakePath;
+        }
 
-test('getWikiPages throws exception on failure', function () {
-    Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response(['message' => 'Not Found'], 404),
-    ]);
+        protected function cloneWikiRepo(string $wikiUrl): string
+        {
+            return $this->fakePath;
+        }
 
-    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
-})->throws(\Exception::class, 'Failed to fetch wiki pages');
+        protected function removeDirectory(string $path): void
+        {
+            // Don't remove during test — we'll clean up manually
+        }
+    };
 
-test('getWikiPage fetches specific wiki page successfully', function () {
-    Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages/home' => Http::response([
-            'slug' => 'home',
-            'title' => 'Home',
-            'content' => '# Welcome',
-        ], 200),
-    ]);
-
-    $result = $this->service->getWikiPage('https://github.com/owner/repo/wiki', 'home');
+    $result = $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
 
     expect($result)->toBeArray()
-        ->and($result['slug'])->toBe('home')
-        ->and($result['content'])->toBe('# Welcome');
+        ->toHaveCount(2);
+
+    $slugs = array_column($result, 'slug');
+    expect($slugs)->toContain('home')
+        ->toContain('installation');
+
+    $homePage = collect($result)->firstWhere('slug', 'home');
+    expect($homePage['content'])->toBe("# Welcome\n\nHome content.");
+
+    // Clean up
+    array_map('unlink', glob("{$tempDir}/*.md"));
+    rmdir($tempDir);
 });
 
-test('getWikiPage throws exception on failure', function () {
-    Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages/nonexistent' => Http::response(['message' => 'Not Found'], 404),
-    ]);
+test('getWikiPagesWithContent handles subdirectories', function () {
+    $tempDir = sys_get_temp_dir().'/test-wiki-'.uniqid();
+    mkdir("{$tempDir}/guides", 0777, true);
+    file_put_contents("{$tempDir}/guides.md", '# Guides');
+    file_put_contents("{$tempDir}/guides/usage.md", '# Usage Guide');
 
-    $this->service->getWikiPage('https://github.com/owner/repo/wiki', 'nonexistent');
-})->throws(\Exception::class, "Failed to fetch wiki page 'nonexistent'");
+    $service = new class('test-token', $tempDir) extends GitHubService
+    {
+        private string $fakePath;
+
+        public function __construct(string $token, string $fakePath)
+        {
+            parent::__construct($token);
+            $this->fakePath = $fakePath;
+        }
+
+        protected function cloneWikiRepo(string $wikiUrl): string
+        {
+            return $this->fakePath;
+        }
+
+        protected function removeDirectory(string $path): void {}
+    };
+
+    $result = $service->getWikiPagesWithContent('https://github.com/owner/repo/wiki');
+
+    $slugs = array_column($result, 'slug');
+    expect($slugs)->toContain('guides')
+        ->toContain('guides/usage');
+
+    $childPage = collect($result)->firstWhere('slug', 'guides/usage');
+    expect($childPage['content'])->toBe('# Usage Guide');
+
+    // Clean up
+    unlink("{$tempDir}/guides.md");
+    unlink("{$tempDir}/guides/usage.md");
+    rmdir("{$tempDir}/guides");
+    rmdir($tempDir);
+});
+
+test('getWikiPagesWithContent throws exception when clone fails', function () {
+    // Use a real service with a bad token — the clone should fail
+    $service = new GitHubService('invalid-token');
+
+    $service->getWikiPagesWithContent('https://github.com/nonexistent-owner-xyz/nonexistent-repo-xyz/wiki');
+})->throws(\Exception::class, 'Failed to clone wiki repository');
 
 test('getFileContent fetches raw file content successfully', function () {
     Http::fake([
@@ -130,26 +174,25 @@ test('extractFilePathFromUrl throws exception for invalid URL', function () {
 
 test('request handles rate limiting', function () {
     Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response(
+        'https://api.github.com/repos/owner/repo/contents/test.md?ref=main' => Http::response(
             ['message' => 'API rate limit exceeded'],
             403,
             ['X-RateLimit-Remaining' => '0', 'X-RateLimit-Reset' => (string) (time() + 60)]
         ),
     ]);
 
-    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+    $this->service->getFileContent('https://github.com/owner/repo/blob/main/test.md');
 })->throws(\Exception::class, 'GitHub API rate limit exceeded');
 
 test('request sends correct authentication headers', function () {
     Http::fake([
-        'https://api.github.com/repos/owner/repo/wiki/pages' => Http::response([], 200),
+        'https://api.github.com/repos/owner/repo/contents/test.md?ref=main' => Http::response('content', 200),
     ]);
 
-    $this->service->getWikiPages('https://github.com/owner/repo/wiki');
+    $this->service->getFileContent('https://github.com/owner/repo/blob/main/test.md');
 
     Http::assertSent(function ($request) {
         return $request->hasHeader('Authorization', 'Bearer test-token')
-            && $request->hasHeader('Accept', 'application/vnd.github+json')
             && $request->hasHeader('X-GitHub-Api-Version', '2022-11-28');
     });
 });


### PR DESCRIPTION
## Summary

- Switch `ImportWikiDocumentation` job from `GitLabService` to `GitHubService`
- Replace non-existent GitHub REST API wiki endpoints with Git clone approach (GitHub wikis are separate `.wiki.git` repos)
- Add `getWikiPagesWithContent()` to `GitHubService` that clones the wiki repo once and returns all pages with content
- Update `EditPackage` to use `github_token` setting for documentation imports
- Fix pre-existing bug where test token values weren't encrypted

Closes #3

## Changes

- `app/Jobs/ImportWikiDocumentation.php` — Use `GitHubService` via container, call `getWikiPagesWithContent()` for single-clone efficiency
- `app/Services/GitHubService.php` — Add wiki Git clone methods: `cloneWikiRepo()`, `parseWikiDirectory()`, `readWikiPage()`, `removeDirectory()`
- `Modules/Packages/app/Livewire/Admin/EditPackage.php` — `importDocumentation()` now reads `github_token` setting
- `tests/Feature/Jobs/ImportWikiDocumentationTest.php` — Mock `GitHubService` via container binding
- `tests/Feature/Services/GitHubServiceTest.php` — Test clone/parse with temp directories
- `tests/Feature/Livewire/EditPackageTest.php` — Update to `github_token`, fix `encrypt()` usage

## Testing

- All 27 related tests passing
- Manually tested against `ArtisanPack-UI/accessibility` wiki — successfully imported documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Wiki documentation import switched from GitLab to GitHub; configuration now uses an encrypted GitHub token and shows “GitHub token not configured” when missing.

* **New Features**
  * Imports include full page content by cloning the wiki repo, preserve title precedence (YAML > H1 > title case > slug), and enforce path-safety for files.
  * Absolute GitHub wiki links are rewritten to internal documentation URLs.

* **Tests**
  * Tests updated for the GitHub cloning flow, token-missing failure, absolute-link rewriting, and path traversal safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->