### PR TITLE
enhancement: update ImportChangelog job for GitHub

### DIFF
--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -102,18 +102,21 @@ class EditPackage extends Component
             return;
         }
 
-        $encryptedToken = Setting::where('key', 'gitlab_token')->first()?->value;
+        $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
 
-        // Decrypt the token (it's stored encrypted for security)
-        $gitlabToken = $encryptedToken ? decrypt($encryptedToken) : null;
+        try {
+            $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
+        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+            $githubToken = null;
+        }
 
-        if (empty($gitlabToken)) {
-            $this->error('GitLab token not configured in settings.');
+        if (empty($githubToken)) {
+            $this->error('GitHub token not configured in settings.');
 
             return;
         }
 
-        ImportChangelog::dispatch($this->package, $gitlabToken);
+        ImportChangelog::dispatch($this->package);
 
         $this->success('Changelog import started! This may take a few moments.');
     }

--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -75,15 +75,7 @@ class EditPackage extends Component
             return;
         }
 
-        $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
-
-        try {
-            $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
-        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
-            $githubToken = null;
-        }
-
-        if (empty($githubToken)) {
+        if (empty($this->resolveGithubToken())) {
             $this->error('GitHub token not configured in settings.');
 
             return;
@@ -102,15 +94,7 @@ class EditPackage extends Component
             return;
         }
 
-        $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
-
-        try {
-            $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
-        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
-            $githubToken = null;
-        }
-
-        if (empty($githubToken)) {
+        if (empty($this->resolveGithubToken())) {
             $this->error('GitHub token not configured in settings.');
 
             return;
@@ -124,6 +108,20 @@ class EditPackage extends Component
     public function updatedName()
     {
         $this->slug = strtolower(str_replace(' ', '-', $this->name));
+    }
+
+    /**
+     * Resolve the GitHub token from encrypted settings
+     */
+    protected function resolveGithubToken(): ?string
+    {
+        $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
+
+        try {
+            return $encryptedToken ? decrypt($encryptedToken) : null;
+        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+            return null;
+        }
     }
 
     public function render()

--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -81,6 +81,9 @@ class EditPackage extends Component
             return;
         }
 
+        // Persist current form values so the queued job uses the latest URL
+        $this->package->update(['wiki_url' => $this->wiki_url]);
+
         ImportWikiDocumentation::dispatch($this->package);
 
         $this->success('Documentation import started! This may take a few moments.');
@@ -99,6 +102,9 @@ class EditPackage extends Component
 
             return;
         }
+
+        // Persist current form values so the queued job uses the latest URL
+        $this->package->update(['changelog_url' => $this->changelog_url]);
 
         ImportChangelog::dispatch($this->package);
 

--- a/app/Jobs/ImportChangelog.php
+++ b/app/Jobs/ImportChangelog.php
@@ -2,10 +2,11 @@
 
 namespace App\Jobs;
 
-use App\Services\GitLabService;
+use App\Services\GitHubService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Setting;
 use Modules\Packages\Changelog;
 use Modules\Packages\Package;
 
@@ -24,8 +25,7 @@ class ImportChangelog implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public Package $package,
-        public string $gitlabToken
+        public Package $package
     ) {}
 
     /**
@@ -34,10 +34,22 @@ class ImportChangelog implements ShouldQueue
     public function handle(): void
     {
         try {
-            $gitlabService = new GitLabService($this->gitlabToken);
+            $encryptedToken = Setting::where('key', 'github_token')->first()?->value;
 
-            // Fetch the changelog content from GitLab
-            $content = $gitlabService->getFileContent($this->package->changelog_url);
+            try {
+                $githubToken = $encryptedToken ? decrypt($encryptedToken) : null;
+            } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                $githubToken = null;
+            }
+
+            if (empty($githubToken)) {
+                throw new \Exception('GitHub token not configured or could not be decrypted');
+            }
+
+            $githubService = app()->make(GitHubService::class, ['token' => $githubToken]);
+
+            // Fetch the changelog content from GitHub
+            $content = $githubService->getFileContent($this->package->changelog_url);
 
             // Remove the first H1 header if it exists
             $content = $this->removeFirstH1Header($content);

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -294,12 +294,24 @@ class GitHubService
         // Example URL formats:
         // https://github.com/owner/repo/blob/main/CHANGELOG.md
         // https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md
+        // https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md
         // Note: Branch names with slashes (e.g., feature/branch) are ambiguous
         // in GitHub URLs and cannot be reliably parsed without an API call to
         // resolve the ref. This pattern assumes single-segment branch names.
 
-        $pattern = '/github\.com\/([^\/]+\/[^\/]+)\/blob\/([^\/]+)\/(.+)/';
-        if (preg_match($pattern, $fileUrl, $matches)) {
+        // Match github.com blob URLs
+        $blobPattern = '/github\.com\/([^\/]+\/[^\/]+)\/blob\/([^\/]+)\/(.+)/';
+        if (preg_match($blobPattern, $fileUrl, $matches)) {
+            return [
+                $matches[1], // repo path (owner/repo)
+                $matches[3], // file path
+                $matches[2], // ref (branch)
+            ];
+        }
+
+        // Match raw.githubusercontent.com URLs
+        $rawPattern = '/raw\.githubusercontent\.com\/([^\/]+\/[^\/]+)\/([^\/]+)\/(.+)/';
+        if (preg_match($rawPattern, $fileUrl, $matches)) {
             return [
                 $matches[1], // repo path (owner/repo)
                 $matches[3], // file path

--- a/tests/Feature/Jobs/ImportChangelogTest.php
+++ b/tests/Feature/Jobs/ImportChangelogTest.php
@@ -17,10 +17,13 @@ beforeEach(function () {
     ]);
 });
 
-function mockGitHubFileContent(string $content): void
+function mockGitHubFileContent(string $expectedUrl, string $content): void
 {
     $mock = Mockery::mock(GitHubService::class);
-    $mock->shouldReceive('getFileContent')->andReturn($content);
+    $mock->shouldReceive('getFileContent')
+        ->once()
+        ->with($expectedUrl)
+        ->andReturn($content);
     app()->bind(GitHubService::class, fn () => $mock);
 }
 
@@ -34,7 +37,7 @@ test('imports changelog successfully', function () {
 
     $changelogContent = "# Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -65,7 +68,7 @@ test('updates existing changelog when re-importing', function () {
 
     $newContent = "# Changelog\n\n## [2.0.0] - 2025-02-01\n- Updated release";
 
-    mockGitHubFileContent($newContent);
+    mockGitHubFileContent($package->changelog_url, $newContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -89,6 +92,8 @@ test('logs error and throws exception on failure', function () {
 
     $mock = Mockery::mock(GitHubService::class);
     $mock->shouldReceive('getFileContent')
+        ->once()
+        ->with($package->changelog_url)
         ->andThrow(new \Exception('Failed to fetch file content'));
     app()->bind(GitHubService::class, fn () => $mock);
 
@@ -134,7 +139,7 @@ test('handles changelog in subdirectory', function () {
 
     $changelogContent = "# Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -159,7 +164,7 @@ test('removes only first H1 header and preserves rest of content', function () {
 
     $changelogContent = "# Changelog\n\nAll notable changes to this project.\n\n## [2.0.0] - 2025-02-01\n- New feature\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -181,7 +186,7 @@ test('handles changelog without H1 header', function () {
 
     $changelogContent = "## [1.0.0] - 2025-01-01\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -200,7 +205,7 @@ test('removes H1 header with leading whitespace', function () {
 
     $changelogContent = "  # Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();
@@ -221,7 +226,7 @@ test('removes long H1 header like Digital Shopfront CMS Accessibility Changelog'
 
     $changelogContent = "# Digital Shopfront CMS Accessibility Changelog\n\n## Version 1.0.0\n- Initial release";
 
-    mockGitHubFileContent($changelogContent);
+    mockGitHubFileContent($package->changelog_url, $changelogContent);
 
     $job = new ImportChangelog($package);
     $job->handle();

--- a/tests/Feature/Jobs/ImportChangelogTest.php
+++ b/tests/Feature/Jobs/ImportChangelogTest.php
@@ -110,6 +110,20 @@ test('throws exception when github token is not configured', function () {
     $job->handle();
 })->throws(\Exception::class, 'GitHub token not configured');
 
+test('throws exception when github token is malformed', function () {
+    Log::shouldReceive('error')->once();
+
+    Setting::where('key', 'github_token')->update(['value' => 'not-encrypted']);
+
+    $package = Package::factory()->create([
+        'name' => 'Test Package',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
+    ]);
+
+    $job = new ImportChangelog($package);
+    $job->handle();
+})->throws(\Exception::class, 'GitHub token not configured');
+
 test('handles changelog in subdirectory', function () {
     Log::shouldReceive('info')->once();
 

--- a/tests/Feature/Jobs/ImportChangelogTest.php
+++ b/tests/Feature/Jobs/ImportChangelogTest.php
@@ -1,29 +1,42 @@
 <?php
 
 use App\Jobs\ImportChangelog;
+use App\Services\GitHubService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Setting;
 use Modules\Packages\Changelog;
 use Modules\Packages\Package;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Setting::create([
+        'key' => 'github_token',
+        'value' => encrypt('test-token'),
+    ]);
+});
+
+function mockGitHubFileContent(string $content): void
+{
+    $mock = Mockery::mock(GitHubService::class);
+    $mock->shouldReceive('getFileContent')->andReturn($content);
+    app()->bind(GitHubService::class, fn () => $mock);
+}
 
 test('imports changelog successfully', function () {
     Log::shouldReceive('info')->once();
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     $changelogContent = "# Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     expect(Changelog::count())->toBe(1);
@@ -41,7 +54,7 @@ test('updates existing changelog when re-importing', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     Changelog::create([
@@ -52,11 +65,9 @@ test('updates existing changelog when re-importing', function () {
 
     $newContent = "# Changelog\n\n## [2.0.0] - 2025-02-01\n- Updated release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($newContent, 200),
-    ]);
+    mockGitHubFileContent($newContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     expect(Changelog::count())->toBe(1);
@@ -73,32 +84,45 @@ test('logs error and throws exception on failure', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response(['error' => 'Not found'], 404),
-    ]);
+    $mock = Mockery::mock(GitHubService::class);
+    $mock->shouldReceive('getFileContent')
+        ->andThrow(new \Exception('Failed to fetch file content'));
+    app()->bind(GitHubService::class, fn () => $mock);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 })->throws(\Exception::class);
+
+test('throws exception when github token is not configured', function () {
+    Log::shouldReceive('error')->once();
+
+    Setting::where('key', 'github_token')->delete();
+
+    $package = Package::factory()->create([
+        'name' => 'Test Package',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
+    ]);
+
+    $job = new ImportChangelog($package);
+    $job->handle();
+})->throws(\Exception::class, 'GitHub token not configured');
 
 test('handles changelog in subdirectory', function () {
     Log::shouldReceive('info')->once();
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/develop/docs/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md',
     ]);
 
     $changelogContent = "# Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/docs%2FCHANGELOG.md/raw?ref=develop' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     expect(Changelog::count())->toBe(1);
@@ -116,16 +140,14 @@ test('removes only first H1 header and preserves rest of content', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     $changelogContent = "# Changelog\n\nAll notable changes to this project.\n\n## [2.0.0] - 2025-02-01\n- New feature\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     $changelog = Changelog::first();
@@ -140,16 +162,14 @@ test('handles changelog without H1 header', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     $changelogContent = "## [1.0.0] - 2025-01-01\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     $changelog = Changelog::first();
@@ -161,16 +181,14 @@ test('removes H1 header with leading whitespace', function () {
 
     $package = Package::factory()->create([
         'name' => 'Test Package',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     $changelogContent = "  # Changelog\n\n## [1.0.0] - 2025-01-01\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     $changelog = Changelog::first();
@@ -184,16 +202,14 @@ test('removes long H1 header like Digital Shopfront CMS Accessibility Changelog'
 
     $package = Package::factory()->create([
         'name' => 'Digital Shopfront CMS Accessibility',
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     $changelogContent = "# Digital Shopfront CMS Accessibility Changelog\n\n## Version 1.0.0\n- Initial release";
 
-    Http::fake([
-        'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/CHANGELOG.md/raw?ref=main' => Http::response($changelogContent, 200),
-    ]);
+    mockGitHubFileContent($changelogContent);
 
-    $job = new ImportChangelog($package, 'test-token');
+    $job = new ImportChangelog($package);
     $job->handle();
 
     $changelog = Changelog::first();

--- a/tests/Feature/Livewire/EditPackageTest.php
+++ b/tests/Feature/Livewire/EditPackageTest.php
@@ -69,11 +69,11 @@ test('import changelog dispatches job when changelog url and token are present',
     Queue::fake();
 
     $package = Package::factory()->create([
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     Setting::create([
-        'key' => 'gitlab_token',
+        'key' => 'github_token',
         'value' => encrypt('test-token-123'),
     ]);
 
@@ -82,7 +82,7 @@ test('import changelog dispatches job when changelog url and token are present',
         ->assertHasNoErrors();
 
     Queue::assertPushed(ImportChangelog::class, function ($job) use ($package) {
-        return $job->package->id === $package->id && $job->gitlabToken === 'test-token-123';
+        return $job->package->id === $package->id;
     });
 });
 
@@ -94,7 +94,7 @@ test('import changelog does not dispatch job when changelog url is missing', fun
     ]);
 
     Setting::create([
-        'key' => 'gitlab_token',
+        'key' => 'github_token',
         'value' => encrypt('test-token-123'),
     ]);
 
@@ -105,11 +105,11 @@ test('import changelog does not dispatch job when changelog url is missing', fun
     Queue::assertNothingPushed();
 });
 
-test('import changelog does not dispatch job when gitlab token is not configured', function () {
+test('import changelog does not dispatch job when github token is not configured', function () {
     Queue::fake();
 
     $package = Package::factory()->create([
-        'changelog_url' => 'https://gitlab.com/group/project/-/blob/main/CHANGELOG.md',
+        'changelog_url' => 'https://github.com/owner/repo/blob/main/CHANGELOG.md',
     ]);
 
     Livewire::test(EditPackage::class, ['package' => $package])

--- a/tests/Feature/Services/GitHubServiceTest.php
+++ b/tests/Feature/Services/GitHubServiceTest.php
@@ -126,6 +126,16 @@ test('getFileContent fetches raw file content successfully', function () {
     expect($result)->toBe('# Changelog content');
 });
 
+test('getFileContent handles raw.githubusercontent.com URLs', function () {
+    Http::fake([
+        'https://api.github.com/repos/owner/repo/contents/CHANGELOG.md?ref=main' => Http::response('# Raw changelog', 200),
+    ]);
+
+    $result = $this->service->getFileContent('https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md');
+
+    expect($result)->toBe('# Raw changelog');
+});
+
 test('getFileContent fetches nested file content successfully', function () {
     Http::fake([
         'https://api.github.com/repos/owner/repo/contents/docs/CHANGELOG.md?ref=develop' => Http::response('# Nested changelog', 200),
@@ -177,6 +187,12 @@ test('extractFilePathFromUrl parses GitHub file URLs correctly', function () {
     expect($result)->toBe(['owner/repo', 'CHANGELOG.md', 'main']);
 
     $result = $method->invoke($service, 'https://github.com/owner/repo/blob/develop/docs/CHANGELOG.md');
+    expect($result)->toBe(['owner/repo', 'docs/CHANGELOG.md', 'develop']);
+
+    $result = $method->invoke($service, 'https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md');
+    expect($result)->toBe(['owner/repo', 'CHANGELOG.md', 'main']);
+
+    $result = $method->invoke($service, 'https://raw.githubusercontent.com/owner/repo/develop/docs/CHANGELOG.md');
     expect($result)->toBe(['owner/repo', 'docs/CHANGELOG.md', 'develop']);
 });
 


### PR DESCRIPTION
## Summary

Update the `ImportChangelog` job to fetch changelog files from GitHub repositories instead of GitLab, matching the same patterns established in PR #14 for `ImportWikiDocumentation`.

Closes #4

## Changes

- `app/Jobs/ImportChangelog.php` — Switch from `GitLabService` to `GitHubService`, remove token from constructor (resolve from settings at runtime), add decrypt error handling
- `Modules/Packages/app/Livewire/Admin/EditPackage.php` — `importChangelog()` now uses `github_token` setting with decrypt error handling, dispatches without token
- `tests/Feature/Jobs/ImportChangelogTest.php` — All 9 tests updated to mock `GitHubService` and use GitHub URLs, added token-not-configured test
- `tests/Feature/Livewire/EditPackageTest.php` — Changelog tests updated to use `github_token` and GitHub URLs

## Testing

- 15 related tests passing (9 job tests + 6 EditPackage tests)
- Manually tested against a real GitHub repository — changelog imported successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changelog importing now uses GitHub (including raw.githubusercontent.com) as the upstream source.

* **Bug Fixes**
  * Better token validation with clearer "GitHub token not configured" errors and graceful handling of missing/malformed credentials.
  * Queued changelog imports no longer include decrypted tokens.

* **Tests**
  * Updated tests to cover GitHub flows, raw URL parsing, and token error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->