### PR TITLE
enhancement: admin UI, tests, and GitHub templates (#7, #8, #9)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,9 +44,43 @@ body:
       required: true
 
   - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Relevant environment details.
+      placeholder: |
+        PHP version: 8.4
+        Laravel version: 12.x
+        Browser: Chrome 120
+        OS: macOS 15
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs/Error Messages
+      description: Any relevant log output, stack traces, or error messages.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - Critical (application crash or data loss)
+        - Major (feature broken, no workaround)
+        - Minor (feature broken, workaround exists)
+    validations:
+      required: false
+
+  - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: Any other context, screenshots, or log output relevant to the issue.
+      description: Any other context or screenshots relevant to the issue.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the details below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or log output relevant to the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/ArtisanPack-UI/artisanpack-ui-docs/discussions
+    about: Ask questions or share ideas in Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature or enhancement.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or references relevant to the request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,22 @@
 
 <!-- Link to the related issue, e.g. Closes #123 -->
 
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
 ## Changes
 
 <!-- Bulleted list of the key changes -->
 
 -
+
+## Breaking Changes
+
+<!-- If applicable, describe any breaking changes and migration steps -->
 
 ## Testing
 
@@ -18,6 +29,14 @@
 
 - [ ] Tests added or updated
 - [ ] Manually tested locally
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Pint formatting passes
+- [ ] Tests pass
+- [ ] Documentation updated (if applicable)
+- [ ] Changelog updated (if applicable)
 
 ## Screenshots
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Brief description of the changes in this PR -->
+
+## Related Issue
+
+<!-- Link to the related issue, e.g. Closes #123 -->
+
+## Changes
+
+<!-- Bulleted list of the key changes -->
+
+-
+
+## Testing
+
+<!-- Describe how these changes were tested -->
+
+- [ ] Tests added or updated
+- [ ] Manually tested locally
+
+## Screenshots
+
+<!-- If applicable, add screenshots to show UI changes -->

--- a/Modules/Admin/resources/views/livewire/settings-page.blade.php
+++ b/Modules/Admin/resources/views/livewire/settings-page.blade.php
@@ -11,7 +11,7 @@
 
             <x-artisanpack-card title="Integrations">
                 <div class="space-y-4">
-                    <x-artisanpack-input wire:model="gitLabToken" label="GitLab Token" type="password" />
+                    <x-artisanpack-input wire:model="gitLabToken" label="GitLab Token" type="password" hint="A GitLab personal access token with the read_api scope." />
 
                     <x-artisanpack-input wire:model="gitHubToken" label="GitHub Token" type="password" hint="A GitHub personal access token (PAT) with the repo scope. Create one at GitHub → Settings → Developer settings → Personal access tokens." />
 

--- a/Modules/Admin/resources/views/livewire/settings-page.blade.php
+++ b/Modules/Admin/resources/views/livewire/settings-page.blade.php
@@ -11,7 +11,7 @@
 
             <x-artisanpack-card title="Integrations">
                 <div class="space-y-4">
-                    <x-artisanpack-input wire:model="gitLabToken" label="GitLab Token" type="password" hint="A GitLab personal access token with the read_api scope." />
+                    <x-artisanpack-input wire:model="gitLabToken" label="GitLab Token" type="password" hint="A GitLab personal access token with the read_api and read_repository scopes. Create one at GitLab → User Settings → Access Tokens." />
 
                     <x-artisanpack-input wire:model="gitHubToken" label="GitHub Token" type="password" hint="A GitHub personal access token (PAT) with the repo scope. Create one at GitHub → Settings → Developer settings → Personal access tokens." />
 

--- a/Modules/Packages/app/Livewire/Admin/AddPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/AddPackage.php
@@ -3,13 +3,16 @@
 namespace Modules\Packages\Livewire\Admin;
 
 use ArtisanPack\LivewireUiComponents\Traits\Toast;
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Modules\Packages\Livewire\Admin\Concerns\HasPackageUrlValidation;
 use Modules\Packages\Package;
 
 #[Layout('admin::layouts.admin')]
 class AddPackage extends Component
 {
+    use HasPackageUrlValidation;
     use Toast;
 
     public string $name = '';
@@ -30,19 +33,14 @@ class AddPackage extends Component
 
     public function addPackage()
     {
-        $validated = $this->validate([
+        $validated = $this->validate(array_merge([
             'name' => 'required|string',
             'slug' => 'required|string',
             'home' => 'nullable|integer',
-            'wiki_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
-            'changelog_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
             'icon' => 'nullable|string',
             'version' => 'nullable|string',
             'package_registry' => 'nullable|in:packagist,npm',
-        ], [
-            'wiki_url.regex' => 'The wiki URL must be a GitHub or GitLab URL.',
-            'changelog_url.regex' => 'The changelog URL must be a GitHub or GitLab URL.',
-        ]);
+        ], $this->packageUrlRules()), $this->packageUrlMessages());
 
         $package = Package::create($validated);
 
@@ -56,7 +54,7 @@ class AddPackage extends Component
         $this->slug = strtolower(str_replace(' ', '-', $this->name));
     }
 
-    public function render()
+    public function render(): View
     {
         return view('packages::livewire.admin.add-package');
     }

--- a/Modules/Packages/app/Livewire/Admin/AddPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/AddPackage.php
@@ -34,11 +34,14 @@ class AddPackage extends Component
             'name' => 'required|string',
             'slug' => 'required|string',
             'home' => 'nullable|integer',
-            'wiki_url' => 'nullable|string',
-            'changelog_url' => 'nullable|string',
+            'wiki_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
+            'changelog_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
             'icon' => 'nullable|string',
             'version' => 'nullable|string',
             'package_registry' => 'nullable|in:packagist,npm',
+        ], [
+            'wiki_url.regex' => 'The wiki URL must be a GitHub or GitLab URL.',
+            'changelog_url.regex' => 'The changelog URL must be a GitHub or GitLab URL.',
         ]);
 
         $package = Package::create($validated);

--- a/Modules/Packages/app/Livewire/Admin/Concerns/HasPackageUrlValidation.php
+++ b/Modules/Packages/app/Livewire/Admin/Concerns/HasPackageUrlValidation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Modules\Packages\Livewire\Admin\Concerns;
+
+trait HasPackageUrlValidation
+{
+    /**
+     * Get the validation rules for package URL fields.
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function packageUrlRules(): array
+    {
+        return [
+            'wiki_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
+            'changelog_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
+        ];
+    }
+
+    /**
+     * Get the custom validation messages for package URL fields.
+     *
+     * @return array<string, string>
+     */
+    protected function packageUrlMessages(): array
+    {
+        return [
+            'wiki_url.regex' => 'The wiki URL must be a GitHub or GitLab URL.',
+            'changelog_url.regex' => 'The changelog URL must be a GitHub or GitLab URL.',
+        ];
+    }
+}

--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -4,7 +4,9 @@ namespace Modules\Packages\Livewire\Admin;
 
 use App\Jobs\ImportChangelog;
 use App\Jobs\ImportWikiDocumentation;
+use App\Services\WikiServiceFactory;
 use ArtisanPack\LivewireUiComponents\Traits\Toast;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Modules\Core\Setting;
@@ -55,11 +57,14 @@ class EditPackage extends Component
             'name' => 'required|string',
             'slug' => 'required|string',
             'homepage' => 'nullable|integer',
-            'wiki_url' => 'nullable|string',
-            'changelog_url' => 'nullable|string',
+            'wiki_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
+            'changelog_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
             'icon' => 'nullable|string',
             'version' => 'nullable|string',
             'package_registry' => 'nullable|in:packagist,npm',
+        ], [
+            'wiki_url.regex' => 'The wiki URL must be a GitHub or GitLab URL.',
+            'changelog_url.regex' => 'The changelog URL must be a GitHub or GitLab URL.',
         ]);
 
         $this->package->update($validated);
@@ -109,6 +114,23 @@ class EditPackage extends Component
         ImportChangelog::dispatch($this->package);
 
         $this->success('Changelog import started! This may take a few moments.');
+    }
+
+    /**
+     * Detect the source platform (GitHub or GitLab) from the wiki URL
+     */
+    #[Computed]
+    public function wikiSource(): ?string
+    {
+        if (empty($this->wiki_url)) {
+            return null;
+        }
+
+        try {
+            return app(WikiServiceFactory::class)->detectSource($this->wiki_url);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     public function updatedName()

--- a/Modules/Packages/app/Livewire/Admin/EditPackage.php
+++ b/Modules/Packages/app/Livewire/Admin/EditPackage.php
@@ -6,15 +6,18 @@ use App\Jobs\ImportChangelog;
 use App\Jobs\ImportWikiDocumentation;
 use App\Services\WikiServiceFactory;
 use ArtisanPack\LivewireUiComponents\Traits\Toast;
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Modules\Core\Setting;
+use Modules\Packages\Livewire\Admin\Concerns\HasPackageUrlValidation;
 use Modules\Packages\Package;
 
 #[Layout('admin::layouts.admin')]
 class EditPackage extends Component
 {
+    use HasPackageUrlValidation;
     use Toast;
 
     public Package $package;
@@ -53,19 +56,14 @@ class EditPackage extends Component
 
     public function updatePackage()
     {
-        $validated = $this->validate([
+        $validated = $this->validate(array_merge([
             'name' => 'required|string',
             'slug' => 'required|string',
             'homepage' => 'nullable|integer',
-            'wiki_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
-            'changelog_url' => ['required', 'url', 'regex:/^https:\/\/(github\.com|gitlab\.com|raw\.githubusercontent\.com)\//'],
             'icon' => 'nullable|string',
             'version' => 'nullable|string',
             'package_registry' => 'nullable|in:packagist,npm',
-        ], [
-            'wiki_url.regex' => 'The wiki URL must be a GitHub or GitLab URL.',
-            'changelog_url.regex' => 'The changelog URL must be a GitHub or GitLab URL.',
-        ]);
+        ], $this->packageUrlRules()), $this->packageUrlMessages());
 
         $this->package->update($validated);
 
@@ -152,7 +150,7 @@ class EditPackage extends Component
         }
     }
 
-    public function render()
+    public function render(): View
     {
         return view('packages::livewire.admin.edit-package');
     }

--- a/Modules/Packages/resources/views/livewire/admin/add-package.blade.php
+++ b/Modules/Packages/resources/views/livewire/admin/add-package.blade.php
@@ -14,7 +14,7 @@
 
                 <x-artisanpack-input wire:model.live="wiki_url" label="Wiki URL" type="url" required hint="GitHub wiki URL (e.g. https://github.com/owner/repo/wiki) or GitLab wiki URL" />
 
-                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md) or GitLab file URL" />
+                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md), raw GitHub URL (raw.githubusercontent.com), or GitLab file URL" />
             </div>
 
             <div class="flex-1">

--- a/Modules/Packages/resources/views/livewire/admin/add-package.blade.php
+++ b/Modules/Packages/resources/views/livewire/admin/add-package.blade.php
@@ -12,9 +12,9 @@
 
                 <x-artisanpack-input wire:model.live="slug" label="Slug" required />
 
-                <x-artisanpack-input wire:model.live="wiki_url" label="Wiki URL" type="url" required />
+                <x-artisanpack-input wire:model.live="wiki_url" label="Wiki URL" type="url" required hint="GitHub wiki URL (e.g. https://github.com/owner/repo/wiki) or GitLab wiki URL" />
 
-                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required />
+                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md) or GitLab file URL" />
             </div>
 
             <div class="flex-1">

--- a/Modules/Packages/resources/views/livewire/admin/edit-package.blade.php
+++ b/Modules/Packages/resources/views/livewire/admin/edit-package.blade.php
@@ -12,9 +12,19 @@
 
                 <x-artisanpack-input wire:model.live="slug" label="Slug" required />
 
-                <x-artisanpack-input wire:model.live="wiki_url" label="Wiki URL" type="url" required />
+                <div>
+                    <x-artisanpack-input wire:model.live="wiki_url" label="Wiki URL" type="url" required hint="GitHub wiki URL (e.g. https://github.com/owner/repo/wiki) or GitLab wiki URL" />
 
-                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required />
+                    @if ($this->wikiSource)
+                        <div class="mt-2">
+                            <flux:badge size="sm" variant="pill" color="{{ $this->wikiSource === 'github' ? 'zinc' : 'orange' }}">
+                                {{ ucfirst($this->wikiSource) }}
+                            </flux:badge>
+                        </div>
+                    @endif
+                </div>
+
+                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md) or GitLab file URL" />
             </div>
 
             <div class="flex-1 space-y-4">

--- a/Modules/Packages/resources/views/livewire/admin/edit-package.blade.php
+++ b/Modules/Packages/resources/views/livewire/admin/edit-package.blade.php
@@ -24,7 +24,7 @@
                     @endif
                 </div>
 
-                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md) or GitLab file URL" />
+                <x-artisanpack-input wire:model.live="changelog_url" label="Changelog URL" type="url" required hint="GitHub file URL (e.g. https://github.com/owner/repo/blob/main/CHANGELOG.md), raw GitHub URL (raw.githubusercontent.com), or GitLab file URL" />
             </div>
 
             <div class="flex-1 space-y-4">

--- a/tests/Feature/Livewire/Admin/AddPackageTest.php
+++ b/tests/Feature/Livewire/Admin/AddPackageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Modules\Packages\Livewire\Admin\AddPackage;
+use Modules\Packages\Package;
+
+uses(RefreshDatabase::class);
+
+test('add package creates package with valid data', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://github.com/owner/repo/blob/main/CHANGELOG.md')
+        ->set('icon', 'ap.puzzle')
+        ->set('version', '1.0.0')
+        ->set('package_registry', 'packagist')
+        ->call('addPackage')
+        ->assertHasNoErrors();
+
+    expect(Package::where('slug', 'test-package')->exists())->toBeTrue();
+});
+
+test('add package auto-generates slug from name', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'My Great Package')
+        ->assertSet('slug', 'my-great-package');
+});
+
+test('add package requires name', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', '')
+        ->set('slug', 'test-package')
+        ->call('addPackage')
+        ->assertHasErrors(['name' => 'required']);
+});
+
+test('add package requires slug', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', '')
+        ->call('addPackage')
+        ->assertHasErrors(['slug' => 'required']);
+});
+
+test('add package rejects non-github and non-gitlab wiki url', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://bitbucket.org/owner/repo/wiki')
+        ->set('changelog_url', 'https://github.com/owner/repo/blob/main/CHANGELOG.md')
+        ->call('addPackage')
+        ->assertHasErrors(['wiki_url' => 'regex']);
+});
+
+test('add package rejects non-github and non-gitlab changelog url', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://bitbucket.org/owner/repo/blob/main/CHANGELOG.md')
+        ->call('addPackage')
+        ->assertHasErrors(['changelog_url' => 'regex']);
+});
+
+test('add package accepts github wiki url', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://github.com/owner/repo/blob/main/CHANGELOG.md')
+        ->call('addPackage')
+        ->assertHasNoErrors(['wiki_url', 'changelog_url']);
+});
+
+test('add package accepts gitlab wiki url', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://gitlab.com/owner/repo/-/wikis/home')
+        ->set('changelog_url', 'https://gitlab.com/owner/repo/-/blob/main/CHANGELOG.md')
+        ->call('addPackage')
+        ->assertHasNoErrors(['wiki_url', 'changelog_url']);
+});
+
+test('add package accepts raw githubusercontent url for changelog', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md')
+        ->call('addPackage')
+        ->assertHasNoErrors(['changelog_url']);
+});
+
+test('add package validates package registry is valid option', function () {
+    Livewire::test(AddPackage::class)
+        ->set('name', 'Test Package')
+        ->set('slug', 'test-package')
+        ->set('package_registry', 'invalid')
+        ->call('addPackage')
+        ->assertHasErrors(['package_registry' => 'in']);
+});

--- a/tests/Feature/Livewire/Admin/AddPackageTest.php
+++ b/tests/Feature/Livewire/Admin/AddPackageTest.php
@@ -64,35 +64,28 @@ test('add package rejects non-github and non-gitlab changelog url', function () 
         ->assertHasErrors(['changelog_url' => 'regex']);
 });
 
-test('add package accepts github wiki url', function () {
+test('add package accepts valid url combinations', function (string $wikiUrl, string $changelogUrl) {
     Livewire::test(AddPackage::class)
         ->set('name', 'Test Package')
         ->set('slug', 'test-package')
-        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
-        ->set('changelog_url', 'https://github.com/owner/repo/blob/main/CHANGELOG.md')
+        ->set('wiki_url', $wikiUrl)
+        ->set('changelog_url', $changelogUrl)
         ->call('addPackage')
         ->assertHasNoErrors(['wiki_url', 'changelog_url']);
-});
-
-test('add package accepts gitlab wiki url', function () {
-    Livewire::test(AddPackage::class)
-        ->set('name', 'Test Package')
-        ->set('slug', 'test-package')
-        ->set('wiki_url', 'https://gitlab.com/owner/repo/-/wikis/home')
-        ->set('changelog_url', 'https://gitlab.com/owner/repo/-/blob/main/CHANGELOG.md')
-        ->call('addPackage')
-        ->assertHasNoErrors(['wiki_url', 'changelog_url']);
-});
-
-test('add package accepts raw githubusercontent url for changelog', function () {
-    Livewire::test(AddPackage::class)
-        ->set('name', 'Test Package')
-        ->set('slug', 'test-package')
-        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
-        ->set('changelog_url', 'https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md')
-        ->call('addPackage')
-        ->assertHasNoErrors(['changelog_url']);
-});
+})->with([
+    'github wiki and changelog' => [
+        'https://github.com/owner/repo/wiki',
+        'https://github.com/owner/repo/blob/main/CHANGELOG.md',
+    ],
+    'gitlab wiki and changelog' => [
+        'https://gitlab.com/owner/repo/-/wikis/home',
+        'https://gitlab.com/owner/repo/-/blob/main/CHANGELOG.md',
+    ],
+    'github wiki with raw githubusercontent changelog' => [
+        'https://github.com/owner/repo/wiki',
+        'https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md',
+    ],
+]);
 
 test('add package validates package registry is valid option', function () {
     Livewire::test(AddPackage::class)

--- a/tests/Feature/Livewire/EditPackageTest.php
+++ b/tests/Feature/Livewire/EditPackageTest.php
@@ -118,3 +118,64 @@ test('import changelog does not dispatch job when github token is not configured
 
     Queue::assertNothingPushed();
 });
+
+test('update package rejects non-github and non-gitlab wiki url', function () {
+    $package = Package::factory()->create();
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->set('name', 'Updated Package')
+        ->set('slug', 'updated-package')
+        ->set('wiki_url', 'https://bitbucket.org/owner/repo/wiki')
+        ->call('updatePackage')
+        ->assertHasErrors(['wiki_url' => 'regex']);
+});
+
+test('update package rejects non-github and non-gitlab changelog url', function () {
+    $package = Package::factory()->create();
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->set('name', 'Updated Package')
+        ->set('slug', 'updated-package')
+        ->set('changelog_url', 'https://bitbucket.org/owner/repo/CHANGELOG.md')
+        ->call('updatePackage')
+        ->assertHasErrors(['changelog_url' => 'regex']);
+});
+
+test('update package accepts github and gitlab urls', function () {
+    $package = Package::factory()->create();
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->set('name', 'Updated Package')
+        ->set('slug', 'updated-package')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://gitlab.com/owner/repo/-/blob/main/CHANGELOG.md')
+        ->call('updatePackage')
+        ->assertHasNoErrors(['wiki_url', 'changelog_url']);
+});
+
+test('wiki source computed property returns github for github urls', function () {
+    $package = Package::factory()->create([
+        'wiki_url' => 'https://github.com/owner/repo/wiki',
+    ]);
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->assertSet('wikiSource', 'github');
+});
+
+test('wiki source computed property returns gitlab for gitlab urls', function () {
+    $package = Package::factory()->create([
+        'wiki_url' => 'https://gitlab.com/owner/repo/-/wikis/home',
+    ]);
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->assertSet('wikiSource', 'gitlab');
+});
+
+test('wiki source computed property returns null when wiki url is empty', function () {
+    $package = Package::factory()->create([
+        'wiki_url' => '',
+    ]);
+
+    Livewire::test(EditPackage::class, ['package' => $package])
+        ->assertSet('wikiSource', null);
+});

--- a/tests/Feature/Livewire/EditPackageTest.php
+++ b/tests/Feature/Livewire/EditPackageTest.php
@@ -119,27 +119,21 @@ test('import changelog does not dispatch job when github token is not configured
     Queue::assertNothingPushed();
 });
 
-test('update package rejects non-github and non-gitlab wiki url', function () {
+test('update package rejects unsupported url', function (string $field, string $url) {
     $package = Package::factory()->create();
 
     Livewire::test(EditPackage::class, ['package' => $package])
         ->set('name', 'Updated Package')
         ->set('slug', 'updated-package')
-        ->set('wiki_url', 'https://bitbucket.org/owner/repo/wiki')
+        ->set('wiki_url', 'https://github.com/owner/repo/wiki')
+        ->set('changelog_url', 'https://github.com/owner/repo/blob/main/CHANGELOG.md')
+        ->set($field, $url)
         ->call('updatePackage')
-        ->assertHasErrors(['wiki_url' => 'regex']);
-});
-
-test('update package rejects non-github and non-gitlab changelog url', function () {
-    $package = Package::factory()->create();
-
-    Livewire::test(EditPackage::class, ['package' => $package])
-        ->set('name', 'Updated Package')
-        ->set('slug', 'updated-package')
-        ->set('changelog_url', 'https://bitbucket.org/owner/repo/CHANGELOG.md')
-        ->call('updatePackage')
-        ->assertHasErrors(['changelog_url' => 'regex']);
-});
+        ->assertHasErrors([$field => 'regex']);
+})->with([
+    'bitbucket wiki url' => ['wiki_url', 'https://bitbucket.org/owner/repo/wiki'],
+    'bitbucket changelog url' => ['changelog_url', 'https://bitbucket.org/owner/repo/CHANGELOG.md'],
+]);
 
 test('update package accepts github and gitlab urls', function () {
     $package = Package::factory()->create();


### PR DESCRIPTION
## Summary
- Add GitHub/GitLab URL format validation with custom error messages to AddPackage and EditPackage forms
- Add source indicator badge (GitHub/GitLab) on the edit package page via computed property
- Add hint text for wiki URL, changelog URL, GitLab token, and GitHub token fields
- Create comprehensive AddPackage tests (10) and EditPackage URL validation + source badge tests (6)
- Create GitHub issue templates (bug report, feature request) and PR template

## Related Issues
Closes #7, closes #8, closes #9

## Test plan
- [x] 22 tests passing (10 AddPackage + 12 EditPackage)
- [x] Existing settings and service factory tests unaffected (15 passing)
- [x] Two clean CodeRabbit review passes
- [x] Pint formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added issue templates (bug report, feature request) and a pull request template; disabled blank issues and added a contact/discussions link.

* **New Features**
  * Centralized stricter package URL validation to accept HTTPS GitHub/GitLab links only.
  * Shows detected wiki source when editing a package.

* **UI Improvements**
  * Added helpful hints to URL input fields.

* **Tests**
  * Added feature tests covering package creation, updates, URL validation, and wiki-source detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->