### PR TITLE
chore: audit artisanpack-ui/* composer packages for L13

### DIFF
--- a/.ai/issue-66-composer-audit.md
+++ b/.ai/issue-66-composer-audit.md
@@ -1,0 +1,56 @@
+# Issue #66 — `artisanpack-ui/*` composer package audit for Laravel 13
+
+Branch: `chore/66-audit-artisanpack-composer-packages`. Companion to milestone v3.0.
+
+## Scope
+
+Per issue #66, audit composer constraints on the in-house `artisanpack-ui/*` packages
+named in the milestone plan: `accessibility`, `core`, `icons`, `security`, `seo`,
+`privacy`, `performance`, `analytics`, `react`. File follow-up issues on any package
+still pinned to `^12.0` only.
+
+The already-shipped Laravel 12 → 13 upgrade (issue #65, PR #125) bumped
+`artisanpack-ui/livewire-ui-components` from `^1.0.0` to `^2.0` as part of the Livewire 4
+migration; that package is covered here as well for completeness.
+
+## Method
+
+For packages currently in `composer.json`, the installed version's `require` block in
+`vendor/artisanpack-ui/<pkg>/composer.json` is the authoritative constraint. For packages
+not yet installed (queued behind separate install issues #97–#100), the latest published
+release on Packagist (`https://repo.packagist.org/p2/artisanpack-ui/<pkg>.json`) is used.
+
+## Findings
+
+### Installed (present in `composer.json`)
+
+| Package | Root constraint | Resolved version | Package's own Laravel constraint | L13 support |
+|---|---|---|---|---|
+| `artisanpack-ui/accessibility` | `^2.0` | 2.3.0 | `illuminate/support: ^12.0\|^13.0` | Yes |
+| `artisanpack-ui/core` | `^1.0` | 1.2.0 | `illuminate/support: ^11.0\|^12.0\|^13.0` | Yes |
+| `artisanpack-ui/icons` | `^2.0` | 2.2.0 | `illuminate/support: ^12.0 \|\| ^13.0` | Yes |
+| `artisanpack-ui/livewire-ui-components` | `^2.0` | 2.1.0 | `illuminate/support: ^10.0\|^11.0\|^12.0\|^13.0` | Yes |
+| `artisanpack-ui/security` | `^1.0` | 1.0.3 | `illuminate/support: >=5.3` | Yes |
+
+### Not yet installed (Packagist latest)
+
+| Package | Latest version | Package's own Laravel constraint | L13 support | Notes |
+|---|---|---|---|---|
+| `artisanpack-ui/seo` | 1.3.0 | `illuminate/support: ^10.0\|^11.0\|^12.0\|^13.0` | Yes | Install work tracked in #97 |
+| `artisanpack-ui/privacy` | 1.1.0 | `illuminate/support: ^10.0\|^11.0\|^12.0\|^13.0` | Yes | Install work tracked in #98 |
+| `artisanpack-ui/performance` | 1.1.0 | `illuminate/support: ^10.0\|^11.0\|^12.0\|^13.0` | Yes | Install work tracked in #99 |
+| `artisanpack-ui/analytics` | 1.4.0 | `illuminate/support: ^11.0\|^12.0\|^13.0` | Yes | Install work tracked in #100 |
+| `artisanpack-ui/react` | n/a | n/a | n/a | Not a Composer package. The `ArtisanPack-UI/react` GitHub repo is the npm monorepo (`@artisanpack-ui/react`, `@artisanpack-ui/tokens`, `@artisanpack-ui/react-laravel`) used by the v3 Inertia + React refactor. Out of scope for a composer audit; JS-side pinning belongs to the frontend workstream. |
+
+## Result
+
+Every Composer package in the audit list already advertises `^13.0` support in its own
+`require` block. No package is pinned to `^12.0` only.
+
+**No follow-up issues need to be filed.** The condition in issue #66 ("File follow-up
+issues on any package pinned to `^12.0`") did not trigger for any package.
+
+## No code changes
+
+This is a documentation-only branch. `composer.json` is left untouched — none of the
+current constraints need widening or bumping to get L13 compatibility.


### PR DESCRIPTION
## Summary

Audit of `artisanpack-ui/*` Composer package constraints for Laravel 13 support, per milestone v3.0 §9.1 plan item #2. Doc-only branch — no `composer.json` changes.

## Related Issue

Closes #66

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

- Added `.ai/issue-66-composer-audit.md` capturing per-package Laravel constraints, methodology (vendor/ for installed, Packagist for uninstalled), and the pass/fail verdict.

## Findings

Every audited Composer package already advertises `^13.0` in its own `require`:

**Installed (in `composer.json`):**
- `accessibility` 2.3.0 — `illuminate/support: ^12.0|^13.0`
- `core` 1.2.0 — `illuminate/support: ^11.0|^12.0|^13.0`
- `icons` 2.2.0 — `illuminate/support: ^12.0 || ^13.0`
- `livewire-ui-components` 2.1.0 — `illuminate/support: ^10.0|^11.0|^12.0|^13.0`
- `security` 1.0.3 — `illuminate/support: >=5.3`

**Not yet installed (queued behind install issues #97–#100, verified against Packagist latest):**
- `seo` 1.3.0 — `illuminate/support: ^10.0|^11.0|^12.0|^13.0`
- `privacy` 1.1.0 — `illuminate/support: ^10.0|^11.0|^12.0|^13.0`
- `performance` 1.1.0 — `illuminate/support: ^10.0|^11.0|^12.0|^13.0`
- `analytics` 1.4.0 — `illuminate/support: ^11.0|^12.0|^13.0`

**Out of scope:**
- `react` — the `ArtisanPack-UI/react` GitHub repo is the npm monorepo (`@artisanpack-ui/react`, `@artisanpack-ui/tokens`, `@artisanpack-ui/react-laravel`) used by the v3 Inertia + React refactor. Not a Composer package; JS-side pinning belongs to the frontend workstream.

**No package is pinned to `^12.0` only.** The condition in issue #66 for filing follow-up issues did not trigger — no follow-ups required.

## Breaking Changes

None. Doc-only.

## Testing

- [ ] Tests added or updated (n/a — doc-only)
- [x] Manually verified constraint strings against `vendor/artisanpack-ui/*/composer.json` (installed) and `https://repo.packagist.org/p2/artisanpack-ui/<pkg>.json` (uninstalled)

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes (n/a — no PHP touched)
- [x] Tests pass (n/a — no code touched)
- [x] Documentation updated (audit notes in `.ai/`)
- [ ] Changelog updated (if applicable) — n/a, internal audit note

## Screenshots

_None — doc-only._