### PR TITLE
feat: enable Inertia SSR bundle for Forge deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules/
 
 # Vite
 /public/build
+/bootstrap/ssr
 
 # Modules (if using nwidart/laravel-modules)
 /Modules/*/node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ public/build-*
 public/hot
 storage
 vendor
+bootstrap/ssr
 composer.lock
 package-lock.json
 Modules/*/node_modules

--- a/docs/inertia-ssr-forge.md
+++ b/docs/inertia-ssr-forge.md
@@ -1,0 +1,144 @@
+# Inertia SSR on Laravel Forge
+
+Runbook for enabling and operating the Inertia server-side renderer for
+`artisanpack-ui-docs` on Laravel Forge. Companion to the wider Forge deploy
+runbook (issue #116); this file is scoped to the SSR daemon and the
+zero-downtime restart pattern used on every deploy.
+
+## What SSR does here
+
+Public docs pages are rendered on the server via a Node.js process so search
+engines and social crawlers receive fully hydrated HTML. React then hydrates
+the same DOM in the browser (`hydrateRoot` in `resources/js/app.tsx`), so no
+re-render blip.
+
+- Client entry: `resources/js/app.tsx` → `public/build/`.
+- Server entry: `resources/js/ssr.tsx` → `bootstrap/ssr/ssr.js`.
+- Server-side glue: the `HandleInertiaRequests` middleware + the
+  `inertia.ssr.*` config in `config/inertia.php`.
+- Daemon command: `php artisan inertia:start-ssr` (listens on
+  `http://127.0.0.1:13714` by default).
+
+Both bundles are produced by `npm run build`, which runs
+`vite build && vite build --ssr`. `bootstrap/ssr/` is git-ignored — the
+bundle is a build artifact.
+
+## Forge setup (one-time)
+
+1. Open the site in Forge → **Application** panel.
+2. Toggle **Inertia SSR** on. Forge creates a daemon that runs
+   `php artisan inertia:start-ssr` from the site root with auto-restart on
+   crash.
+3. Confirm the deploy script includes the SSR restart step (see below). If
+   Forge did not add it automatically, patch it manually.
+4. Confirm the site's `.env` has `NODE_ENV=production` and the correct
+   `APP_URL`. `VITE_APP_NAME` is optional (defaults to
+   `"ArtisanPack UI Docs"`).
+
+No extra env vars are required for SSR itself — `inertia.ssr.enabled` and
+`inertia.ssr.url` come from `config/inertia.php` and are safe to leave at
+the defaults.
+
+## Deploy script
+
+The deploy script must build both bundles **before** restarting the SSR
+daemon so the new bundle is on disk when the daemon reloads:
+
+```bash
+cd /home/forge/docs.artisanpack.dev
+
+git pull origin release/3.0
+
+$FORGE_COMPOSER install --no-interaction --prefer-dist --optimize-autoloader --no-dev
+
+# Client + SSR bundles. `npm ci` keeps the install deterministic against
+# package-lock.json; `npm run build` writes public/build/ AND
+# bootstrap/ssr/ssr.js.
+npm ci --no-audit --no-fund
+npm run build
+
+( flock -w 10 9 || exit 1
+    echo 'Restarting FPM...'
+    sudo -S service $FORGE_PHP_FPM reload ) 9>/tmp/fpmlock
+
+$FORGE_PHP artisan migrate --force
+$FORGE_PHP artisan config:cache
+$FORGE_PHP artisan route:cache
+$FORGE_PHP artisan view:cache
+$FORGE_PHP artisan event:cache
+
+# Zero-downtime SSR restart — must run AFTER npm run build so the daemon
+# reloads against the freshly written bootstrap/ssr/ssr.js.
+$FORGE_PHP artisan inertia:stop-ssr
+```
+
+`inertia:stop-ssr` returns immediately; Forge's daemon supervisor sees the
+exit and re-launches `php artisan inertia:start-ssr` within a second or two.
+Requests that land during the restart fall back to client-side rendering
+because `inertia.ssr.ensure_bundle_exists` is `true` (the middleware skips
+SSR when the bundle isn't reachable, so no visitor sees a 500).
+
+## Zero-downtime restart pattern
+
+The pattern is: **build fully, then reload the daemon** — never the other
+way around.
+
+1. `npm ci && npm run build` writes the new `bootstrap/ssr/ssr.js`
+   atomically (Vite writes to a temp file, then renames).
+2. `php artisan inertia:stop-ssr` sends the running Node process a shutdown
+   signal. In-flight renders finish before the process exits.
+3. Forge's supervisor auto-restarts the daemon. The new process loads the
+   new bundle on boot.
+4. During steps 2–3, the middleware falls through to CSR — the page still
+   loads, just without pre-rendered HTML. Crawlers see a brief window of
+   CSR-only responses; humans don't notice.
+
+No `--force`, `kill -9`, or manual `supervisorctl restart` is needed. If
+Forge's daemon supervisor is misconfigured and the process does not come
+back up, see **Rollback**.
+
+## Health check
+
+After deploy, from the Forge site's SSH console:
+
+```bash
+php artisan inertia:check-ssr
+```
+
+Exits `0` and prints the SSR server status when healthy; non-zero when the
+daemon is down or the bundle is missing. Wire this into the post-deploy
+smoke check (issue #113) once the staging environment exists.
+
+You can also curl the daemon directly:
+
+```bash
+curl -s http://127.0.0.1:13714/health
+```
+
+## Rollback
+
+If a deploy leaves SSR broken (bundle fails to load, daemon crash-loops,
+`inertia:check-ssr` non-zero):
+
+1. **Immediate**: turn off the **Inertia SSR** toggle in Forge. The daemon
+   stops; the middleware falls back to CSR for every request. Site stays
+   up.
+2. Investigate the SSR log — Forge exposes the daemon's stdout/stderr from
+   the daemon detail page.
+3. If the bundle itself is bad, roll the deploy back (`git checkout` the
+   prior tag, re-run `npm run build`) and re-enable SSR.
+4. If it's a config or env issue, fix it, re-deploy, then re-enable the
+   toggle.
+
+CSR fallback is not a permanent posture — SEO parity is the reason SSR is
+on — but it is the correct panic button while root-causing.
+
+## Related
+
+- `resources/js/ssr.tsx` — server entry point.
+- `resources/js/app.tsx` — matching client entry (uses `hydrateRoot`).
+- `vite.config.js` — `ssr: 'resources/js/ssr.tsx'` on the Laravel plugin.
+- `package.json` — `build: "vite build && vite build --ssr"`.
+- `config/inertia.php` — SSR toggle, URL, `ensure_bundle_exists`.
+- Issue #116 — full Forge deploy runbook (SSR is one section of it).
+- Issue #113 — SSR staging dry-run + Lighthouse gate.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build --ssr",
     "dev": "vite",
     "lint": "eslint 'resources/js/**/*.{ts,tsx}' 'Modules/*/resources/js/**/*.{ts,tsx}' --cache --cache-location node_modules/.cache/eslint --no-error-on-unmatched-pattern",
     "format": "prettier --write --cache --no-error-on-unmatched-pattern 'resources/{css,js}/**/*.{ts,tsx,js,jsx,json,css}' 'Modules/*/resources/js/**/*.{ts,tsx}'",

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -1,0 +1,41 @@
+import { createInertiaApp } from '@inertiajs/react';
+import createServer from '@inertiajs/react/server';
+import type { ComponentType } from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+const appName = import.meta.env.VITE_APP_NAME || 'ArtisanPack UI Docs';
+
+const rootPages = import.meta.glob<{ default: ComponentType }>('./pages/**/*.tsx', { eager: true });
+const modulePages = import.meta.glob<{ default: ComponentType }>(
+    '../../Modules/*/resources/js/pages/**/*.tsx',
+    { eager: true },
+);
+
+const resolvePage = (name: string) => {
+    if (name.includes('::')) {
+        const [module, page] = name.split('::');
+        const key = `../../Modules/${module}/resources/js/pages/${page}.tsx`;
+        const found = modulePages[key];
+        if (!found) {
+            throw new Error(`Inertia SSR page not found: ${name} (${key})`);
+        }
+        return found.default;
+    }
+
+    const key = `./pages/${name}.tsx`;
+    const found = rootPages[key];
+    if (!found) {
+        throw new Error(`Inertia SSR page not found: ${name} (${key})`);
+    }
+    return found.default;
+};
+
+createServer((page) =>
+    createInertiaApp({
+        page,
+        render: ReactDOMServer.renderToString,
+        title: (title) => (title ? `${title} - ${appName}` : appName),
+        resolve: resolvePage,
+        setup: ({ App, props }) => <App {...props} />,
+    }),
+);

--- a/tests/Feature/InertiaSsrTest.php
+++ b/tests/Feature/InertiaSsrTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+it('has SSR enabled in Inertia config', function () {
+    expect(config('inertia.ssr.enabled'))->toBeTrue();
+});
+
+it('points Inertia SSR at a local Node bundle port', function () {
+    $url = config('inertia.ssr.url');
+
+    expect($url)
+        ->toBeString()
+        ->toStartWith('http://127.0.0.1:');
+});
+
+it('ships an SSR entry point at resources/js/ssr.tsx', function () {
+    $entry = base_path('resources/js/ssr.tsx');
+
+    expect(file_exists($entry))->toBeTrue();
+
+    $contents = (string) file_get_contents($entry);
+
+    expect($contents)
+        ->toContain("from '@inertiajs/react/server'")
+        ->toContain('ReactDOMServer.renderToString')
+        ->toContain('import.meta.glob')
+        ->toContain('./pages/**/*.tsx')
+        ->toContain('../../Modules/*/resources/js/pages/**/*.tsx');
+});
+
+it('registers the SSR entry with Vite', function () {
+    $config = (string) file_get_contents(base_path('vite.config.js'));
+
+    expect($config)->toContain("ssr: 'resources/js/ssr.tsx'");
+});
+
+it('builds the SSR bundle as part of npm run build', function () {
+    $package = json_decode((string) file_get_contents(base_path('package.json')), true);
+
+    expect($package['scripts']['build'] ?? '')
+        ->toContain('vite build')
+        ->toContain('--ssr');
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
                 'resources/js/app.tsx',
                 ...moduleAssets,
             ],
+            ssr: 'resources/js/ssr.tsx',
             refresh: true,
         }),
         react(),


### PR DESCRIPTION
## Summary

Adds the server entry point and build pipeline pieces the Forge Inertia SSR daemon needs. The daemon itself (`php artisan inertia:start-ssr`) and the deploy-script wiring are toggled in the Forge site panel when the 3.0 site is provisioned — this PR is the codebase half of that setup.

## Related Issue

Closes #69

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

- **`resources/js/ssr.tsx`** — React SSR entry using `@inertiajs/react/server` + `ReactDOMServer.renderToString`. Mirrors `app.tsx` page resolution (root pages + `Module::Page` convention) with eager glob imports, and reuses the same `import.meta.env.VITE_APP_NAME` title so client and SSR emit identical `<title>` output.
- **`vite.config.js`** — register `ssr: 'resources/js/ssr.tsx'` on the Laravel plugin.
- **`package.json`** — `build` now runs `vite build && vite build --ssr` so a single `npm run build` produces both bundles (`public/build/` + `bootstrap/ssr/ssr.js`).
- **`.gitignore` + `.prettierignore`** — `bootstrap/ssr` is a build artifact.
- **`tests/Feature/InertiaSsrTest.php`** — guards SSR config, entry-file shape, Vite input, and build-script wiring.
- **`docs/inertia-ssr-forge.md`** — runbook: Forge toggle, deploy script, zero-downtime restart pattern (build first, then `inertia:stop-ssr`; supervisor auto-restarts against the new bundle), health check, rollback.

## Testing

- [x] Tests added or updated — 5 new tests in `tests/Feature/InertiaSsrTest.php` (all pass; full suite 183 pass, 526 assertions).
- [x] Manually tested locally — `php artisan inertia:start-ssr` renders `Welcome` via `POST http://127.0.0.1:13714/render` (HTTP 200, hydrated HTML with the actual `<h1>` in the body). `inertia:stop-ssr` cleanly shuts down; `inertia:check-ssr` reports status correctly.
- Forge daemon setup is deferred until the 3.0 site is provisioned; the runbook documents the one-time enable steps.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [x] Documentation updated (if applicable) — new runbook at `docs/inertia-ssr-forge.md`
- [ ] Changelog updated (if applicable) — 3.0 changelog entry lives on #115

## Screenshots

N/A — no UI changes. SSR is a build/runtime concern; the rendered output is identical to the current CSR page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side rendering support for Inertia pages.
  * Added SSR support for both core and modular page components.
  * Builds now include both client-side and server-side bundles.

* **Documentation**
  * Added setup, deployment, health-check, rollback, and troubleshooting guidance for SSR hosting.

* **Tests**
  * Added coverage validating SSR configuration, entry points, build settings, and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->