### PR TITLE
feat: adopt @artisanpack-ui/react; drop Mary UI residuals

### DIFF
--- a/Modules/Core/resources/views/partials/head.blade.php
+++ b/Modules/Core/resources/views/partials/head.blade.php
@@ -55,13 +55,4 @@
 
 @stack('styles')
 
-<script>
-    // On page load or when changing themes, best to add inline in `head` to avoid FOUC
-    if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        document.documentElement.classList.add('dark')
-    } else {
-        document.documentElement.setAttribute('data-theme', 'light');
-        document.documentElement.classList.remove('dark')
-    }
-</script>
+@include('partials.theme-boot')

--- a/Modules/Core/resources/views/partials/header.blade.php
+++ b/Modules/Core/resources/views/partials/header.blade.php
@@ -6,14 +6,8 @@
             <span class="sr-only">ArtisanPack UI</span>
         </a>
 
-        <div
-            class="flex-1 min-w-0 order-3 md:order-2 w-full md:w-auto cursor-pointer"
-            onclick="setTimeout(() => window.dispatchEvent(new CustomEvent('mary-search-open', { bubbles: true })), 10);"
-            onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setTimeout(() => window.dispatchEvent(new CustomEvent('mary-search-open', { bubbles: true })), 10); }"
-            role="button"
-            tabindex="0"
-            aria-label="{{ __('Open search') }}"
-        >
+        {{-- Visual placeholder for the React SearchOverlay landing in #88. Hidden from AT until wired. --}}
+        <div class="flex-1 min-w-0 order-3 md:order-2 w-full md:w-auto" aria-hidden="true">
             <x-artisanpack-input
                 :placeholder="__('Search...')"
                 icon="fas.magnifying-glass"
@@ -26,13 +20,13 @@
             <x-artisanpack-theme-toggle class="btn btn-sm md:btn-md" />
 
             <div class="border-l border-secondary flex items-center pl-2 gap-1 md:gap-2">
-                <a href="https://github.com/ArtisanPack-UI" target="_blank" class="hover:text-primary">
+                <a href="https://github.com/ArtisanPack-UI" target="_blank" rel="noopener noreferrer" class="hover:text-primary">
                     <x-artisanpack-icon name="fab.github" class="w-4 h-4 md:w-5 md:h-5" />
                 </a>
-                <a href="https://bsky.app/profile/artisanpackui.dev" target="_blank" class="hover:text-primary">
+                <a href="https://bsky.app/profile/artisanpackui.dev" target="_blank" rel="noopener noreferrer" class="hover:text-primary">
                     <x-artisanpack-icon name="fab.bluesky" class="w-4 h-4 md:w-5 md:h-5" />
                 </a>
-                <a href="https://mastodon.social/@artisanpackui" target="_blank" class="hover:text-primary">
+                <a href="https://mastodon.social/@artisanpackui" target="_blank" rel="noopener noreferrer" class="hover:text-primary">
                     <x-artisanpack-icon name="fab.mastodon" class="w-4 h-4 md:w-5 md:h-5" />
                 </a>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,17 @@
     "": {
       "dependencies": {
         "@artisanpack-ui/livewire-drag-and-drop": "^2.0.0",
+        "@artisanpack-ui/react": "^1.0.1",
+        "@artisanpack-ui/tokens": "^1.0.1",
         "@inertiajs/react": "^2.3.27",
+        "apexcharts": "^3.54.1",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
         "glob": "^11.0.3",
         "laravel-vite-plugin": "^1.0",
         "react": "^19.2.8",
+        "react-apexcharts": "~1.5.0",
         "react-dom": "^19.2.8",
         "vite": "^6.0"
       },
@@ -48,6 +52,45 @@
       "license": "MIT",
       "dependencies": {
         "alpinejs": "^3.15.0"
+      }
+    },
+    "node_modules/@artisanpack-ui/react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@artisanpack-ui/react/-/react-1.0.1.tgz",
+      "integrity": "sha512-4ezSErVTPhNzB7uIvErDSafyVzbKwKDRp/TPAiCwwxQ5gsqSGLIsMPHFrxQQpmljKZRKNke+KnJ++Yl4+8OUuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@artisanpack-ui/tokens": "*"
+      },
+      "peerDependencies": {
+        "apexcharts": "^3.41.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-apexcharts": "^1.5.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "apexcharts": {
+          "optional": true
+        },
+        "react-apexcharts": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@artisanpack-ui/tokens": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@artisanpack-ui/tokens/-/tokens-1.0.1.tgz",
+      "integrity": "sha512-2JsR0n3x0v97d2eqjc44BVzEpWzn9bxmonSYWkTCCq+KFaU9K4jUFU7+Vpw0O40mwgOkw1BKbvduvCJJ+MqACw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "clsx": "^2.1.0",
+        "tailwind-merge": "^3.0.0",
+        "tailwindcss": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "tailwindcss": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2177,6 +2220,12 @@
       "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
       "license": "MIT"
     },
+    "node_modules/@yr/monotone-cubic-spline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2260,6 +2309,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.54.1.tgz",
+      "integrity": "sha512-E4et0h/J1U3r3EwS/WlqJCQIbepKbp6wGUmaAwJOMjHUP4Ci0gxanLa7FR3okx6p9coi4st6J853/Cb1NP0vpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@yr/monotone-cubic-spline": "^1.0.3",
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/argparse": {
@@ -2669,6 +2733,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4550,7 +4624,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4975,7 +5048,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5126,7 +5198,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5451,7 +5522,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5503,6 +5573,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-apexcharts": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.5.0.tgz",
+      "integrity": "sha512-RwIqhYee8tT6WsDR9I15bhDuPitM+z/P092QPttFR5D57M21/WtYKHE9JQMbcz9bmF35rfDSym1SZuZ7AhidhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "apexcharts": "^3.41.0",
+        "react": ">=0.13"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
@@ -5519,7 +5602,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -6136,11 +6218,113 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": ">=2.3.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+      "license": "MIT"
+    },
+    "node_modules/svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js/node_modules/svg.select.js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,17 @@
   },
   "dependencies": {
     "@artisanpack-ui/livewire-drag-and-drop": "^2.0.0",
+    "@artisanpack-ui/react": "^1.0.1",
+    "@artisanpack-ui/tokens": "^1.0.1",
     "@inertiajs/react": "^2.3.27",
+    "apexcharts": "^3.54.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.4",
     "concurrently": "^9.0.1",
     "glob": "^11.0.3",
     "laravel-vite-plugin": "^1.0",
     "react": "^19.2.8",
+    "react-apexcharts": "~1.5.0",
     "react-dom": "^19.2.8",
     "vite": "^6.0"
   },

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,13 @@
 @import 'tailwindcss';
+@import '@artisanpack-ui/tokens/css';
 
 @source '../js/**/*.tsx';
 @source '../js/**/*.ts';
 @source '../../Modules/*/resources/js/**/*.tsx';
+@source '../../node_modules/@artisanpack-ui/react/dist/**/*.mjs';
+
+@plugin "daisyui" {
+    themes: light --default, dark --prefersdark;
+}
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/resources/js/AppShell.tsx
+++ b/resources/js/AppShell.tsx
@@ -1,0 +1,37 @@
+import { ThemeProvider, useTheme, type ColorScheme } from '@artisanpack-ui/react';
+import { useEffect, type ReactNode } from 'react';
+
+const isBrowser = typeof document !== 'undefined';
+
+function readInitialColorScheme(): ColorScheme {
+    if (!isBrowser) {
+        return 'light';
+    }
+    const attr = document.documentElement.getAttribute('data-theme');
+    return attr === 'dark' ? 'dark' : 'light';
+}
+
+function ThemeDomSync({ children }: { children: ReactNode }) {
+    const { resolvedColorScheme } = useTheme();
+
+    useEffect(() => {
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolvedColorScheme);
+        root.classList.toggle('dark', resolvedColorScheme === 'dark');
+        try {
+            localStorage.setItem('theme', resolvedColorScheme);
+        } catch {
+            // localStorage disabled (private mode / disk full) — the DOM sync is enough.
+        }
+    }, [resolvedColorScheme]);
+
+    return <>{children}</>;
+}
+
+export function AppShell({ children }: { children: ReactNode }) {
+    return (
+        <ThemeProvider defaultColorScheme={readInitialColorScheme()}>
+            <ThemeDomSync>{children}</ThemeDomSync>
+        </ThemeProvider>
+    );
+}

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -3,6 +3,8 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { ComponentType } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 
+import { AppShell } from './AppShell';
+
 const appName = import.meta.env.VITE_APP_NAME || 'ArtisanPack UI Docs';
 
 const rootPages = import.meta.glob<{ default: ComponentType }>('./pages/**/*.tsx');
@@ -26,12 +28,18 @@ createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
     resolve: resolvePage,
     setup({ el, App, props }) {
+        const tree = (
+            <AppShell>
+                <App {...props} />
+            </AppShell>
+        );
+
         if (el.hasChildNodes()) {
-            hydrateRoot(el, <App {...props} />);
+            hydrateRoot(el, tree);
             return;
         }
 
-        createRoot(el).render(<App {...props} />);
+        createRoot(el).render(tree);
     },
     progress: {
         color: '#4B5563',

--- a/resources/js/pages/Welcome.tsx
+++ b/resources/js/pages/Welcome.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@artisanpack-ui/react/form';
+import { Card } from '@artisanpack-ui/react/layout';
 import { Head } from '@inertiajs/react';
 
 export default function Welcome() {
@@ -5,12 +7,20 @@ export default function Welcome() {
         <>
             <Head title="Welcome" />
             <main className="min-h-screen flex items-center justify-center p-8">
-                <div className="text-center">
+                <Card className="max-w-xl w-full text-center">
                     <h1 className="text-4xl font-bold">ArtisanPack UI Docs</h1>
                     <p className="mt-4 text-lg opacity-70">
-                        Inertia + React + TypeScript foundation is live.
+                        Inertia + React + TypeScript + @artisanpack-ui/react is live.
                     </p>
-                </div>
+                    <div className="mt-6 flex justify-center gap-3">
+                        <Button color="primary" link="https://artisanpackui.dev" external>
+                            View docs
+                        </Button>
+                        <Button color="outline" link="https://github.com/ArtisanPack-UI" external>
+                            GitHub
+                        </Button>
+                    </div>
+                </Card>
             </main>
         </>
     );

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -3,6 +3,8 @@ import createServer from '@inertiajs/react/server';
 import type { ComponentType } from 'react';
 import ReactDOMServer from 'react-dom/server';
 
+import { AppShell } from './AppShell';
+
 const appName = import.meta.env.VITE_APP_NAME || 'ArtisanPack UI Docs';
 
 const rootPages = import.meta.glob<{ default: ComponentType }>('./pages/**/*.tsx', { eager: true });
@@ -36,6 +38,10 @@ createServer((page) =>
         render: ReactDOMServer.renderToString,
         title: (title) => (title ? `${title} - ${appName}` : appName),
         resolve: resolvePage,
-        setup: ({ App, props }) => <App {...props} />,
+        setup: ({ App, props }) => (
+            <AppShell>
+                <App {...props} />
+            </AppShell>
+        ),
     }),
 );

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -11,6 +11,8 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
+        @include('partials.theme-boot')
+
         @viteReactRefresh
         @vite(['resources/css/app.css', 'resources/js/app.tsx'])
         @inertiaHead

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -11,13 +11,4 @@
 
 @vite(['resources/css/app.css', 'resources/js/auth.js'])
 
-<script>
-    // On page load or when changing themes, best to add inline in `head` to avoid FOUC
-    if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        document.documentElement.classList.add('dark')
-    } else {
-        document.documentElement.setAttribute('data-theme', 'light');
-        document.documentElement.classList.remove('dark')
-    }
-</script>
+@include('partials.theme-boot')

--- a/resources/views/partials/theme-boot.blade.php
+++ b/resources/views/partials/theme-boot.blade.php
@@ -1,0 +1,12 @@
+{{-- Runs synchronously in <head> to resolve the color scheme before first paint (no FOUC). --}}
+<script>
+    (function () {
+        var stored;
+        try { stored = localStorage.getItem('theme'); } catch (e) { stored = null; }
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored === 'dark' || stored === 'light' ? stored : (prefersDark ? 'dark' : 'light');
+        var root = document.documentElement;
+        root.setAttribute('data-theme', theme);
+        root.classList.toggle('dark', theme === 'dark');
+    })();
+</script>

--- a/tests/Feature/HeaderPartialTest.php
+++ b/tests/Feature/HeaderPartialTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+it('marks the pending search block as aria-hidden until #88 lands the React SearchOverlay', function () {
+    $header = (string) file_get_contents(base_path('Modules/Core/resources/views/partials/header.blade.php'));
+
+    expect($header)->toContain('aria-hidden="true"');
+});
+
+it('sets rel="noopener noreferrer" on every target="_blank" anchor in the header', function () {
+    $header = (string) file_get_contents(base_path('Modules/Core/resources/views/partials/header.blade.php'));
+
+    preg_match_all('/<a[^>]*target="_blank"[^>]*>/', $header, $matches);
+
+    expect($matches[0])->not->toBeEmpty();
+
+    foreach ($matches[0] as $anchor) {
+        expect($anchor)->toContain('rel="noopener noreferrer"');
+    }
+});
+
+it('does not re-introduce Mary UI search-open handlers', function () {
+    $header = (string) file_get_contents(base_path('Modules/Core/resources/views/partials/header.blade.php'));
+
+    expect($header)
+        ->not->toContain('mary-search-open')
+        ->not->toContain('role="button"');
+});

--- a/tests/Feature/InertiaFoundationTest.php
+++ b/tests/Feature/InertiaFoundationTest.php
@@ -28,12 +28,18 @@ it('boots the theme on the Inertia root before Vite loads to avoid FOUC', functi
         ->toResponse(request())
         ->getContent();
 
+    // The Blade @vite directive renders differently in dev (public/hot present, dev URLs) vs
+    // prod (build/manifest.json present, hashed asset URLs). Both modes emit type="module" on
+    // the app entry script, so use that as the manifest-agnostic anchor for Vite's output.
     $bootPos = strpos($html, "root.setAttribute('data-theme', theme)");
-    $vitePos = strpos($html, '/resources/js/app.tsx');
+    $viteModulePos = strpos($html, 'type="module"');
+    $headClosePos = strpos($html, '</head>');
 
     expect($bootPos)->not->toBeFalse();
-    expect($vitePos)->not->toBeFalse();
-    expect($bootPos)->toBeLessThan($vitePos);
+    expect($viteModulePos)->not->toBeFalse();
+    expect($headClosePos)->not->toBeFalse();
+    expect($bootPos)->toBeLessThan($viteModulePos);
+    expect($bootPos)->toBeLessThan($headClosePos);
 });
 
 it('wraps the Inertia app in the shared AppShell (theme provider + DOM sync)', function () {

--- a/tests/Feature/InertiaFoundationTest.php
+++ b/tests/Feature/InertiaFoundationTest.php
@@ -22,3 +22,36 @@ it('renders the root Blade template as valid HTML for an Inertia page', function
         ->toContain('data-page=')
         ->toContain('type="module"');
 });
+
+it('boots the theme on the Inertia root before Vite loads to avoid FOUC', function () {
+    $html = Inertia::render('Welcome')
+        ->toResponse(request())
+        ->getContent();
+
+    $bootPos = strpos($html, "root.setAttribute('data-theme', theme)");
+    $vitePos = strpos($html, '/resources/js/app.tsx');
+
+    expect($bootPos)->not->toBeFalse();
+    expect($vitePos)->not->toBeFalse();
+    expect($bootPos)->toBeLessThan($vitePos);
+});
+
+it('wraps the Inertia app in the shared AppShell (theme provider + DOM sync)', function () {
+    $entry = (string) file_get_contents(base_path('resources/js/app.tsx'));
+    $ssr = (string) file_get_contents(base_path('resources/js/ssr.tsx'));
+
+    expect($entry)
+        ->toContain("import { AppShell } from './AppShell'")
+        ->toContain('<AppShell>');
+    expect($ssr)
+        ->toContain("import { AppShell } from './AppShell'")
+        ->toContain('<AppShell>');
+});
+
+it('syncs ThemeProvider color scheme onto the document root', function () {
+    $shell = (string) file_get_contents(base_path('resources/js/AppShell.tsx'));
+
+    expect($shell)
+        ->toContain("root.setAttribute('data-theme', resolvedColorScheme)")
+        ->toContain("root.classList.toggle('dark', resolvedColorScheme === 'dark')");
+});

--- a/tests/Feature/ThemeBootTest.php
+++ b/tests/Feature/ThemeBootTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+it('ships a shared theme boot partial with a synchronous IIFE', function () {
+    $partial = (string) file_get_contents(base_path('resources/views/partials/theme-boot.blade.php'));
+
+    expect($partial)
+        ->toContain('<script>')
+        ->toContain('(function ()')
+        ->toContain("localStorage.getItem('theme')")
+        ->toContain('prefers-color-scheme: dark')
+        ->toContain("root.setAttribute('data-theme', theme)")
+        ->toContain("root.classList.toggle('dark', theme === 'dark')");
+});
+
+it('includes the shared theme boot partial from every Blade root', function () {
+    $inertiaRoot = (string) file_get_contents(base_path('resources/views/app.blade.php'));
+    $authHead = (string) file_get_contents(base_path('resources/views/partials/head.blade.php'));
+    $livewireHead = (string) file_get_contents(base_path('Modules/Core/resources/views/partials/head.blade.php'));
+
+    expect($inertiaRoot)->toContain("@include('partials.theme-boot')");
+    expect($authHead)->toContain("@include('partials.theme-boot')");
+    expect($livewireHead)->toContain("@include('partials.theme-boot')");
+});
+
+it('does not duplicate the inline theme boot script outside the shared partial', function () {
+    $roots = [
+        base_path('resources/views/app.blade.php'),
+        base_path('resources/views/partials/head.blade.php'),
+        base_path('Modules/Core/resources/views/partials/head.blade.php'),
+    ];
+
+    foreach ($roots as $path) {
+        $contents = (string) file_get_contents($path);
+
+        expect($contents)->not->toContain("localStorage.getItem('theme') === 'dark'");
+    }
+});


### PR DESCRIPTION
## Summary

Adopts `@artisanpack-ui/react` for the React/Inertia stack, drops the Mary UI residuals from the header partial, and wires theme handling end-to-end (ThemeProvider ↔ DOM sync ↔ pre-hydration Blade boot script) so DaisyUI theming actually works in the new Inertia stack.

## Related Issue

Closes #70

## Type of Change

- [x] New feature

## Changes

- Install `@artisanpack-ui/react` + `@artisanpack-ui/tokens`, and pin `apexcharts@^3` / `react-apexcharts@~1.5.0` to the versions AP-UI React's peer contract accepts (React 19 peers already in place from #68).
- Wire the React-side CSS through `@artisanpack-ui/tokens` and register the DaisyUI plugin against the AP-UI React dist source in `resources/css/app.css`.
- Extract `resources/js/AppShell.tsx`:
  - Wraps in `<ThemeProvider>` with an SSR-safe initial color scheme (`typeof document === 'undefined'` → `'light'`, matching AP-UI React's `getServerSnapshot`; on client reads `<html data-theme>` set by the boot script below).
  - `ThemeDomSync` inner component consumes `useTheme()` and mirrors `resolvedColorScheme` onto `document.documentElement` (`data-theme` + `.dark` class) + persists to `localStorage`. Without this the ThemeProvider is decorative — Tailwind `dark:` utilities and DaisyUI theme switching never activate.
  - Consumed from both `resources/js/app.tsx` and `resources/js/ssr.tsx`, so no drift between client and SSR.
- Extract `resources/views/partials/theme-boot.blade.php` — synchronous IIFE that reads `localStorage.theme` / `matchMedia` and sets `data-theme` + `.dark` on `<html>` before Vite loads. `@include`d from all three Blade roots (Inertia app, auth head, Livewire Core head), replacing two pre-existing inline duplicates.
- Drop the Mary UI `mary-search-open` handlers from `Modules/Core/resources/views/partials/header.blade.php`. Mark the pending search block `aria-hidden="true"` (the placeholder input is unreachable and non-interactive until the real React `SearchOverlay` ships in #88). Add `rel="noopener noreferrer"` to the three `target="_blank"` social anchors — pre-existing tabnabbing risk that this PR is the natural moment to close since it touches the file.
- Prove the wiring with `resources/js/pages/Welcome.tsx` rendering `Button` (from `/form`) + `Card` (from `/layout`) via subpath imports.

## Breaking Changes

None. The Livewire home page and all auth flows continue to render through the existing HomePage/Livewire routes; the theme boot script is behavior-equivalent to the removed inline duplicates.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally (via build + type check; visual smoke deferred to #82 when `/` ports to Inertia)

**192 tests passing / 554 assertions** (+9 new):
- `tests/Feature/ThemeBootTest.php` — shared partial exists with the IIFE, all three roots `@include` it, none still carry the inline duplicate.
- `tests/Feature/HeaderPartialTest.php` — pending search block is `aria-hidden`, every `target="_blank"` anchor carries `rel="noopener noreferrer"`, no Mary UI regressions.
- Extended `tests/Feature/InertiaFoundationTest.php` — theme boot script is sequenced before `@vite` in the Inertia root, `AppShell` is wired into both entries, DOM sync lives in AppShell.

Also passing: `npm run types`, `npm run lint`, `npm run build` (client + SSR), `vendor/bin/pint --dirty`.

## Deferred (follow-up work)

- **Bundle size (`app-*.js` is 1.1 MB / 314 KB gzip).** `@artisanpack-ui/react@1.0.1`'s `/utility` subpath only re-exports Icon/ThemeToggle/Tooltip/Clipboard/Markdown — NOT `ThemeProvider` or `useTheme` — and the package's `exports` map blocks deep-imports into `./dist/chunk-*.mjs`. So `AppShell` must still import from the root barrel, which pulls the whole library (Chart + ~400KB of ApexCharts). Welcome.tsx already uses subpath imports to set the pattern. Full fix requires an upstream AP-UI React release exposing ThemeProvider under `/utility` (or `sideEffects: false` on the package). Should be filed on `ArtisanPack-UI/react`.
- **DaisyUI stanza duplication across 8 CSS entries.** Best consolidated in the same follow-up that retires the module CSS entries per `.ai/issue-67-livewire-removal-plan.md` (#114).
- **Tailwind `@source` glob width.** Coupled to the bundle-size follow-up above — while the root barrel is imported at entry, every chunk contributes classes anyway.
- **Full DaisyUI npm removal.** Deferred to #114 per the Livewire removal plan; DaisyUI is currently required by AP-UI React itself and by six Livewire module CSS files.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [x] Documentation updated (if applicable) — n/a
- [x] Changelog updated (if applicable) — deferred to #115 (3.0 changelog bundle)

## Screenshots

n/a — the Welcome page isn't routed yet (that lands in #82); this PR is verified via build + tests.