### PR TITLE
feat: shared Inertia layouts (Public/Docs/Admin/Auth)

### DIFF
--- a/resources/js/layouts/AdminLayout.tsx
+++ b/resources/js/layouts/AdminLayout.tsx
@@ -1,0 +1,76 @@
+import { Link, usePage } from '@inertiajs/react';
+import { ThemeToggle } from '@artisanpack-ui/react';
+import type { ReactNode } from 'react';
+
+export interface AdminNavItem {
+    label: string;
+    href: string;
+}
+
+export interface AdminLayoutProps {
+    children: ReactNode;
+    title?: string;
+    nav?: AdminNavItem[];
+}
+
+const DEFAULT_NAV: AdminNavItem[] = [
+    { label: 'Dashboard', href: '/dashboard' },
+    { label: 'Packages', href: '/dashboard/packages' },
+    { label: 'Pages', href: '/dashboard/pages' },
+    { label: 'Settings', href: '/dashboard/settings' },
+];
+
+export function AdminLayout({ children, title, nav = DEFAULT_NAV }: AdminLayoutProps) {
+    const { url } = usePage();
+
+    return (
+        <div className="min-h-screen bg-base text-text" style={{ display: 'grid', gridTemplateColumns: '260px 1fr' }}>
+            <aside className="border-r border-border-subtle bg-surface-2" aria-label="Admin navigation">
+                <div className="sticky top-0 flex h-screen flex-col">
+                    <div className="border-b border-border-subtle px-6 py-4">
+                        <Link href="/dashboard" className="font-display text-lg font-semibold tracking-tight">
+                            ArtisanPack UI
+                        </Link>
+                        <p className="mt-1 text-xsmall uppercase tracking-wider text-text-subtle">Admin</p>
+                    </div>
+                    <nav className="flex-1 overflow-y-auto px-3 py-4">
+                        <ul className="flex flex-col gap-1">
+                            {nav.map((item) => {
+                                const active = url === item.href || url.startsWith(`${item.href}/`);
+                                return (
+                                    <li key={item.href}>
+                                        <Link
+                                            href={item.href}
+                                            className={`flex items-center gap-3 rounded-box px-3 py-2 text-small transition ${
+                                                active
+                                                    ? 'bg-surface text-secondary'
+                                                    : 'text-text-muted hover:bg-surface hover:text-text'
+                                            }`}
+                                        >
+                                            <span>{item.label}</span>
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </nav>
+                </div>
+            </aside>
+
+            <div className="flex min-w-0 flex-col">
+                <header
+                    className="sticky top-0 z-30 border-b border-border-subtle backdrop-blur-[14px]"
+                    style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
+                >
+                    <div className="flex items-center justify-between gap-4 px-8 py-4">
+                        <h1 className="font-display text-h5">{title}</h1>
+                        <ThemeToggle />
+                    </div>
+                </header>
+                <main className="flex-1 px-8 py-8">{children}</main>
+            </div>
+        </div>
+    );
+}
+
+export default AdminLayout;

--- a/resources/js/layouts/AdminLayout.tsx
+++ b/resources/js/layouts/AdminLayout.tsx
@@ -23,6 +23,11 @@ const DEFAULT_NAV: AdminNavItem[] = [
 export function AdminLayout({ children, title, nav = DEFAULT_NAV }: AdminLayoutProps) {
     const { url } = usePage();
 
+    // Longest-prefix wins so /dashboard/packages highlights Packages, not both Packages and Dashboard.
+    const activeHref = nav
+        .filter((item) => url === item.href || url.startsWith(`${item.href}/`))
+        .sort((a, b) => b.href.length - a.href.length)[0]?.href;
+
     return (
         <div className="min-h-screen bg-base text-text" style={{ display: 'grid', gridTemplateColumns: '260px 1fr' }}>
             <aside className="border-r border-border-subtle bg-surface-2" aria-label="Admin navigation">
@@ -36,7 +41,7 @@ export function AdminLayout({ children, title, nav = DEFAULT_NAV }: AdminLayoutP
                     <nav className="flex-1 overflow-y-auto px-3 py-4">
                         <ul className="flex flex-col gap-1">
                             {nav.map((item) => {
-                                const active = url === item.href || url.startsWith(`${item.href}/`);
+                                const active = item.href === activeHref;
                                 return (
                                     <li key={item.href}>
                                         <Link
@@ -58,12 +63,9 @@ export function AdminLayout({ children, title, nav = DEFAULT_NAV }: AdminLayoutP
             </aside>
 
             <div className="flex min-w-0 flex-col">
-                <header
-                    className="sticky top-0 z-30 border-b border-border-subtle backdrop-blur-[14px]"
-                    style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
-                >
+                <header className="sticky top-0 z-30 border-b border-border-subtle bg-base/90 backdrop-blur-[14px]">
                     <div className="flex items-center justify-between gap-4 px-8 py-4">
-                        <h1 className="font-display text-h5">{title}</h1>
+                        {title ? <h1 className="font-display text-h5">{title}</h1> : <span />}
                         <ThemeToggle />
                     </div>
                 </header>

--- a/resources/js/layouts/AuthLayout.tsx
+++ b/resources/js/layouts/AuthLayout.tsx
@@ -1,0 +1,38 @@
+import { Link } from '@inertiajs/react';
+import { Card } from '@artisanpack-ui/react/layout';
+import type { ReactNode } from 'react';
+
+export interface AuthLayoutProps {
+    children: ReactNode;
+    title?: string;
+    description?: string;
+}
+
+export function AuthLayout({ children, title, description }: AuthLayoutProps) {
+    return (
+        <div className="ap-aurora min-h-screen bg-base text-text">
+            <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12">
+                <Link href="/" className="mb-8 font-display text-xl font-semibold tracking-tight">
+                    ArtisanPack UI
+                </Link>
+
+                <Card className="w-full max-w-md">
+                    {title ? (
+                        <header className="mb-6 text-center">
+                            <h1 className="font-display text-h4">{title}</h1>
+                            {description ? <p className="mt-2 text-small text-text-muted">{description}</p> : null}
+                        </header>
+                    ) : null}
+
+                    {children}
+                </Card>
+
+                <p className="mt-6 text-xsmall text-text-subtle">
+                    © {new Date().getFullYear()} ArtisanPack UI
+                </p>
+            </div>
+        </div>
+    );
+}
+
+export default AuthLayout;

--- a/resources/js/layouts/DocsLayout.tsx
+++ b/resources/js/layouts/DocsLayout.tsx
@@ -1,0 +1,93 @@
+import { Link } from '@inertiajs/react';
+import { ThemeToggle } from '@artisanpack-ui/react';
+import type { ReactNode } from 'react';
+
+const SEARCH_ICON_PATH = 'M21 21l-4.35-4.35M17 10a7 7 0 11-14 0 7 7 0 0114 0z';
+const GITHUB_ICON_PATH =
+    'M12 .5a11.5 11.5 0 00-3.63 22.42c.58.1.79-.25.79-.56v-2.01c-3.2.7-3.88-1.36-3.88-1.36-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.73-1.55-2.56-.29-5.26-1.28-5.26-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.03 11.03 0 015.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.4-5.27 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.55A11.5 11.5 0 0012 .5z';
+
+export interface DocsLayoutProps {
+    children: ReactNode;
+    sidebar?: ReactNode;
+    toc?: ReactNode;
+    onSearchOpen?: () => void;
+}
+
+export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutProps) {
+    return (
+        <div className="min-h-screen bg-base text-text">
+            <header
+                className="sticky top-0 z-40 backdrop-blur-[14px]"
+                style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
+            >
+                <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-6 px-6 py-4">
+                    <Link href="/" className="font-display text-lg font-semibold tracking-tight">
+                        ArtisanPack UI
+                    </Link>
+
+                    <button
+                        type="button"
+                        onClick={onSearchOpen}
+                        className="hidden max-w-md flex-1 items-center gap-2 rounded-box border border-border-subtle bg-surface px-4 py-2 text-left text-small text-text-muted transition hover:border-border md:flex"
+                        aria-label="Open search (⌘K)"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            width="16"
+                            height="16"
+                            aria-hidden
+                        >
+                            <path d={SEARCH_ICON_PATH} />
+                        </svg>
+                        <span className="flex-1">Search the docs…</span>
+                        <kbd className="rounded border border-border-subtle px-1.5 py-0.5 font-mono text-xsmall">⌘K</kbd>
+                    </button>
+
+                    <div className="flex items-center gap-3">
+                        <ThemeToggle />
+                        <a
+                            href="https://github.com/ArtisanPack-UI"
+                            aria-label="GitHub"
+                            className="text-text-muted transition hover:text-secondary"
+                        >
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 24 24"
+                                fill="currentColor"
+                                width="20"
+                                height="20"
+                                aria-hidden
+                            >
+                                <path d={GITHUB_ICON_PATH} />
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+                <div className="h-[2px] w-full" style={{ backgroundImage: 'var(--grad-neon)' }} aria-hidden />
+            </header>
+
+            <div
+                className="mx-auto grid w-full max-w-[1440px] gap-8 px-6 py-8"
+                style={{ gridTemplateColumns: '290px 1fr 264px' }}
+            >
+                <aside className="sticky top-[89px] h-[calc(100vh-89px)] overflow-y-auto pr-2" aria-label="Documentation navigation">
+                    {sidebar}
+                </aside>
+
+                <main className="min-w-0">{children}</main>
+
+                <aside className="sticky top-[89px] h-[calc(100vh-89px)] overflow-y-auto pl-2" aria-label="Table of contents">
+                    {toc}
+                </aside>
+            </div>
+        </div>
+    );
+}
+
+export default DocsLayout;

--- a/resources/js/layouts/DocsLayout.tsx
+++ b/resources/js/layouts/DocsLayout.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@inertiajs/react';
 import { ThemeToggle } from '@artisanpack-ui/react';
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
 const SEARCH_ICON_PATH = 'M21 21l-4.35-4.35M17 10a7 7 0 11-14 0 7 7 0 0114 0z';
 const GITHUB_ICON_PATH =
@@ -14,11 +14,31 @@ export interface DocsLayoutProps {
 }
 
 export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutProps) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const headerRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+        const root = rootRef.current;
+        const header = headerRef.current;
+        if (!root || !header || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        const sync = () => {
+            root.style.setProperty('--docs-header-h', `${header.offsetHeight}px`);
+        };
+        sync();
+
+        const observer = new ResizeObserver(sync);
+        observer.observe(header);
+        return () => observer.disconnect();
+    }, []);
+
     return (
-        <div className="min-h-screen bg-base text-text">
+        <div ref={rootRef} className="min-h-screen bg-base text-text">
             <header
-                className="sticky top-0 z-40 backdrop-blur-[14px]"
-                style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
+                ref={headerRef}
+                className="sticky top-0 z-40 bg-base/90 backdrop-blur-[14px]"
             >
                 <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-6 px-6 py-4">
                     <Link href="/" className="font-display text-lg font-semibold tracking-tight">
@@ -72,17 +92,28 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                 <div className="h-[2px] w-full" style={{ backgroundImage: 'var(--grad-neon)' }} aria-hidden />
             </header>
 
-            <div
-                className="mx-auto grid w-full max-w-[1440px] gap-8 px-6 py-8"
-                style={{ gridTemplateColumns: '290px 1fr 264px' }}
-            >
-                <aside className="sticky top-[89px] h-[calc(100vh-89px)] overflow-y-auto pr-2" aria-label="Documentation navigation">
+            <div className="mx-auto grid w-full max-w-[1440px] grid-cols-1 gap-8 px-6 py-8 xl:grid-cols-[290px_1fr_264px]">
+                <aside
+                    className="sticky hidden overflow-y-auto pr-2 xl:block"
+                    style={{
+                        top: 'var(--docs-header-h, 76px)',
+                        maxHeight: 'calc(100vh - var(--docs-header-h, 76px))',
+                    }}
+                    aria-label="Documentation navigation"
+                >
                     {sidebar}
                 </aside>
 
                 <main className="min-w-0">{children}</main>
 
-                <aside className="sticky top-[89px] h-[calc(100vh-89px)] overflow-y-auto pl-2" aria-label="Table of contents">
+                <aside
+                    className="sticky hidden overflow-y-auto pl-2 xl:block"
+                    style={{
+                        top: 'var(--docs-header-h, 76px)',
+                        maxHeight: 'calc(100vh - var(--docs-header-h, 76px))',
+                    }}
+                    aria-label="Table of contents"
+                >
                     {toc}
                 </aside>
             </div>

--- a/resources/js/layouts/PublicLayout.tsx
+++ b/resources/js/layouts/PublicLayout.tsx
@@ -1,0 +1,61 @@
+import { Link } from '@inertiajs/react';
+import { ThemeToggle } from '@artisanpack-ui/react';
+import type { ReactNode } from 'react';
+
+export interface PublicLayoutProps {
+    children: ReactNode;
+    activeNav?: string;
+}
+
+export function PublicLayout({ children, activeNav }: PublicLayoutProps) {
+    return (
+        <div className="min-h-screen flex flex-col bg-base text-text">
+            <header
+                className="sticky top-0 z-40 border-b border-border-subtle backdrop-blur-[14px]"
+                style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
+            >
+                <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-6 px-6 py-4">
+                    <Link href="/" className="font-display text-lg font-semibold tracking-tight">
+                        ArtisanPack UI
+                    </Link>
+                    <nav className="hidden items-center gap-6 text-small md:flex" aria-label="Primary">
+                        <Link
+                            href="/documentation"
+                            className={`hover:text-secondary ${activeNav === 'docs' ? 'text-secondary' : 'text-text-muted'}`}
+                        >
+                            Docs
+                        </Link>
+                        <Link
+                            href="/changelogs"
+                            className={`hover:text-secondary ${activeNav === 'changelogs' ? 'text-secondary' : 'text-text-muted'}`}
+                        >
+                            Changelogs
+                        </Link>
+                    </nav>
+                    <div className="flex items-center gap-3">
+                        <ThemeToggle />
+                    </div>
+                </div>
+                <div className="h-[2px] w-full" style={{ backgroundImage: 'var(--grad-neon)' }} aria-hidden />
+            </header>
+
+            <main className="flex-1">{children}</main>
+
+            <footer className="border-t border-border-subtle bg-surface-2">
+                <div className="mx-auto flex w-full max-w-[1440px] flex-col items-center justify-between gap-4 px-6 py-8 text-small text-text-muted md:flex-row">
+                    <p>© {new Date().getFullYear()} ArtisanPack UI</p>
+                    <div className="flex items-center gap-4">
+                        <a href="https://github.com/ArtisanPack-UI" className="hover:text-secondary">
+                            GitHub
+                        </a>
+                        <a href="https://artisanpackui.dev" className="hover:text-secondary">
+                            artisanpackui.dev
+                        </a>
+                    </div>
+                </div>
+            </footer>
+        </div>
+    );
+}
+
+export default PublicLayout;

--- a/resources/js/layouts/PublicLayout.tsx
+++ b/resources/js/layouts/PublicLayout.tsx
@@ -10,10 +10,7 @@ export interface PublicLayoutProps {
 export function PublicLayout({ children, activeNav }: PublicLayoutProps) {
     return (
         <div className="min-h-screen flex flex-col bg-base text-text">
-            <header
-                className="sticky top-0 z-40 border-b border-border-subtle backdrop-blur-[14px]"
-                style={{ backgroundColor: 'rgba(8, 12, 22, 0.9)' }}
-            >
+            <header className="sticky top-0 z-40 border-b border-border-subtle bg-base/90 backdrop-blur-[14px]">
                 <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-6 px-6 py-4">
                     <Link href="/" className="font-display text-lg font-semibold tracking-tight">
                         ArtisanPack UI

--- a/tests/Feature/SharedLayoutsTest.php
+++ b/tests/Feature/SharedLayoutsTest.php
@@ -12,26 +12,57 @@ it('ships all four shared Inertia layouts', function () {
 it('renders DocsLayout with the 3-column precision-rail grid', function () {
     $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
 
-    expect($source)->toContain("gridTemplateColumns: '290px 1fr 264px'");
+    expect($source)->toContain('xl:grid-cols-[290px_1fr_264px]');
 });
 
-it('gives DocsLayout a sticky top bar with grad-neon hairline and backdrop-blur', function () {
+it('gives DocsLayout a theme-aware sticky top bar with grad-neon hairline and backdrop-blur', function () {
     $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
 
     expect($source)
         ->toContain('sticky top-0')
         ->toContain('backdrop-blur-[14px]')
-        ->toContain('rgba(8, 12, 22, 0.9)')
+        ->toContain('bg-base/90')
         ->toContain('var(--grad-neon)');
 });
 
-it('gives PublicLayout the same sticky top bar treatment', function () {
+it('measures the DocsLayout header height so sticky rails track it', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
+
+    expect($source)
+        ->toContain('--docs-header-h')
+        ->toContain('ResizeObserver');
+});
+
+it('gives PublicLayout the same theme-aware sticky top bar treatment', function () {
     $source = (string) file_get_contents(base_path('resources/js/layouts/PublicLayout.tsx'));
 
     expect($source)
         ->toContain('sticky top-0')
         ->toContain('backdrop-blur-[14px]')
+        ->toContain('bg-base/90')
         ->toContain('var(--grad-neon)');
+});
+
+it('collapses DocsLayout to a single column below xl to avoid overflow on narrow viewports', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
+
+    expect($source)
+        ->toContain('grid-cols-1')
+        ->toContain('xl:grid-cols-[290px_1fr_264px]');
+});
+
+it('picks a single active AdminLayout nav item by longest-prefix match', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/AdminLayout.tsx'));
+
+    expect($source)
+        ->toContain('activeHref')
+        ->toContain('b.href.length - a.href.length');
+});
+
+it('does not emit an empty AdminLayout heading when title is omitted', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/AdminLayout.tsx'));
+
+    expect($source)->toContain('title ? <h1');
 });
 
 it('gives AdminLayout a sidebar shell', function () {

--- a/tests/Feature/SharedLayoutsTest.php
+++ b/tests/Feature/SharedLayoutsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+it('ships all four shared Inertia layouts', function () {
+    foreach (['PublicLayout', 'DocsLayout', 'AdminLayout', 'AuthLayout'] as $layout) {
+        expect(file_exists(base_path("resources/js/layouts/{$layout}.tsx")))
+            ->toBeTrue("Missing layout: {$layout}");
+    }
+});
+
+it('renders DocsLayout with the 3-column precision-rail grid', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
+
+    expect($source)->toContain("gridTemplateColumns: '290px 1fr 264px'");
+});
+
+it('gives DocsLayout a sticky top bar with grad-neon hairline and backdrop-blur', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
+
+    expect($source)
+        ->toContain('sticky top-0')
+        ->toContain('backdrop-blur-[14px]')
+        ->toContain('rgba(8, 12, 22, 0.9)')
+        ->toContain('var(--grad-neon)');
+});
+
+it('gives PublicLayout the same sticky top bar treatment', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/PublicLayout.tsx'));
+
+    expect($source)
+        ->toContain('sticky top-0')
+        ->toContain('backdrop-blur-[14px]')
+        ->toContain('var(--grad-neon)');
+});
+
+it('gives AdminLayout a sidebar shell', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/AdminLayout.tsx'));
+
+    expect($source)
+        ->toContain("gridTemplateColumns: '260px 1fr'")
+        ->toContain('Admin navigation');
+});
+
+it('gives AuthLayout an aurora background with a centered card', function () {
+    $source = (string) file_get_contents(base_path('resources/js/layouts/AuthLayout.tsx'));
+
+    expect($source)
+        ->toContain('ap-aurora')
+        ->toContain('items-center justify-center')
+        ->toContain('Card');
+});


### PR DESCRIPTION
## Summary

Adds the four shared Inertia layouts called out in `V2_REFACTOR_PLAN.md` §9.1 item #8.

- **DocsLayout** — "1a Precision rail" 3-column `290px | 1fr | 264px` grid; sticky top bar with `--grad-neon` hairline + `backdrop-filter: blur(14px)`; ⌘K search trigger; sticky sidebar + TOC rails.
- **PublicLayout** — sticky top bar (same treatment) + footer, primary nav placeholder.
- **AdminLayout** — 260px sidebar shell for `/dashboard/*` with active-route highlighting; default nav (Dashboard / Packages / Pages / Settings) overridable via prop.
- **AuthLayout** — centered `Card` on `.ap-aurora` backdrop for Fortify screens.

Closes #72.

## Changes

- `resources/js/layouts/{PublicLayout,DocsLayout,AdminLayout,AuthLayout}.tsx`
- `tests/Feature/SharedLayoutsTest.php` — asserts each layout ships with the required structural markers (grid dimensions, sticky-bar hairline, aurora backdrop, sidebar shell).

## Testing

- `php artisan test tests/Feature/SharedLayoutsTest.php` → 6/6 pass
- `npx tsc --noEmit` → clean
- `vendor/bin/pint --dirty` → passed

## Notes

- Layouts are structural shells; the docs sidebar tree, TOC generator, ⌘K search overlay, and admin nav data will land in follow-up issues (per the plan).
- Icons are inline SVG rather than an icon-name registry — `@artisanpack-ui/react`'s `Icon` takes a `path`, not a `name`. Happy to swap to a lookup helper once we build one.