### PR TITLE
feat: typed page-prop contracts for Inertia controllers

### DIFF
--- a/app/Http/HandleInertiaRequests.php
+++ b/app/Http/HandleInertiaRequests.php
@@ -4,8 +4,29 @@ declare(strict_types=1);
 
 namespace App\Http;
 
+use Illuminate\Http\Request;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
 {
+    /**
+     * Shared props available on every Inertia response.
+     *
+     * Keep the shape in sync with `SharedProps` in
+     * `resources/js/types/inertia.d.ts`.
+     *
+     * @return array<string, mixed>
+     */
+    public function share(Request $request): array
+    {
+        return [
+            ...parent::share($request),
+            'flash' => [
+                'success' => fn () => $request->session()->get('success'),
+                'error' => fn () => $request->session()->get('error'),
+                'info' => fn () => $request->session()->get('info'),
+                'warning' => fn () => $request->session()->get('warning'),
+            ],
+        ];
+    }
 }

--- a/resources/js/types/inertia.d.ts
+++ b/resources/js/types/inertia.d.ts
@@ -1,0 +1,22 @@
+import '@inertiajs/core';
+
+declare module '@inertiajs/core' {
+    interface InertiaConfig {
+        sharedPageProps: SharedProps;
+        flashDataType: FlashData;
+    }
+}
+
+export interface FlashData {
+    success?: string;
+    error?: string;
+    info?: string;
+    warning?: string;
+}
+
+export interface SharedProps {
+    [key: string]: unknown;
+    flash: FlashData;
+}
+
+export type PageProps<T extends object = object> = T & SharedProps;

--- a/resources/js/types/pages.ts
+++ b/resources/js/types/pages.ts
@@ -1,0 +1,21 @@
+/**
+ * Per-page prop contracts.
+ *
+ * Every Inertia controller must declare its page prop shape here and
+ * consume it from its page component:
+ *
+ * ```ts
+ * // resources/js/types/pages.ts
+ * export type PackageShowPageProps = PageProps<{
+ *     package: { name: string; slug: string };
+ * }>;
+ *
+ * // resources/js/pages/Packages/Show.tsx
+ * export default function Show({ package: pkg }: PackageShowPageProps) { ... }
+ * ```
+ *
+ * `PageProps<T>` layers T on top of the app-wide `SharedProps` contract
+ * declared in `inertia.d.ts`, so shared keys (like `flash`) stay
+ * available on every page without repeating them.
+ */
+export type { PageProps, SharedProps, FlashData } from './inertia';

--- a/tests/Feature/InertiaSharedPropsTest.php
+++ b/tests/Feature/InertiaSharedPropsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\HandleInertiaRequests;
+use Illuminate\Http\Request;
+
+it('shares flash keys on every Inertia response', function () {
+    $request = Request::create('/');
+    $request->setLaravelSession(app('session.store'));
+    $request->session()->flash('success', 'Saved!');
+    $request->session()->flash('error', 'Boom.');
+    $request->session()->flash('info', 'FYI');
+    $request->session()->flash('warning', 'Careful');
+
+    $shared = app(HandleInertiaRequests::class)->share($request);
+
+    expect($shared)->toHaveKey('flash');
+
+    $flash = collect($shared['flash'])->map(fn ($value) => is_callable($value) ? $value() : $value)->all();
+
+    expect($flash)->toMatchArray([
+        'success' => 'Saved!',
+        'error' => 'Boom.',
+        'info' => 'FYI',
+        'warning' => 'Careful',
+    ]);
+});
+
+it('exposes the SharedProps TypeScript contract that mirrors the middleware', function () {
+    $contract = (string) file_get_contents(base_path('resources/js/types/inertia.d.ts'));
+
+    expect($contract)
+        ->toContain("declare module '@inertiajs/core'")
+        ->toContain('sharedPageProps: SharedProps')
+        ->toContain('interface SharedProps')
+        ->toContain('flash: FlashData');
+});
+
+it('provides a PageProps helper for per-page contracts', function () {
+    $contract = (string) file_get_contents(base_path('resources/js/types/inertia.d.ts'));
+
+    expect($contract)->toContain('export type PageProps');
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
             ],
             ssr: 'resources/js/ssr.tsx',
             refresh: true,
+            detectTls: true,
         }),
         react(),
         tailwindcss(),


### PR DESCRIPTION
## Summary

Lays down the TypeScript foundation for §9.1 plan item #9: a single source of truth for Inertia page-prop contracts, wired into `@inertiajs/core` via module augmentation so `usePage()` returns the app-wide shared shape by default and every controller can declare a per-page prop type that composes on top.

## Related Issue

Closes #73

## Type of Change

- [x] New feature

## Changes

- `resources/js/types/inertia.d.ts` — module-augments `@inertiajs/core` so `SharedPageProps` = the app's `SharedProps`; also exposes `PageProps<T>` and `FlashData` helpers.
- `resources/js/types/pages.ts` — barrel + documented pattern for adding per-controller prop shapes as controllers land.
- `app/Http/HandleInertiaRequests::share()` — emits `flash.{success,error,info,warning}` closures, matching `SharedProps` one-to-one.
- `vite.config.js` — enable `detectTls: true` so Herd's HTTPS `.test` domain serves Vite assets over the same origin during `composer run dev`.
- `tests/Feature/InertiaSharedPropsTest.php` — asserts the middleware share shape, and grep-guards the TS contract file's public surface.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

Manually verified via a temporary demo page (`/__inertia-contract-demo`, since removed): confirmed `heading` + `items` render from typed page props, and each of the four flash levels round-trips through a POST → redirect → shared prop.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared flash notifications for success, error, informational, and warning messages across Inertia pages.
  - Added consistent TypeScript types for shared page data and per-page props.

- **Developer Experience**
  - Enabled automatic TLS detection for the development server.

- **Tests**
  - Added coverage confirming flash data and shared property type contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->