### PR TITLE
feat: port /login to Inertia + Fortify with AP-UI form components

### DIFF
--- a/Modules/Auth/routes/web.php
+++ b/Modules/Auth/routes/web.php
@@ -1,43 +1,40 @@
 <?php
 
+use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Livewire\Actions\Logout;
 use Illuminate\Support\Facades\Route;
 use Modules\Auth\Http\Controllers\AuthController;
-use App\Http\Controllers\Auth\VerifyEmailController;
 use Modules\Auth\Livewire\Auth\ConfirmPassword;
 use Modules\Auth\Livewire\Auth\ForgotPassword;
-use Modules\Auth\Livewire\Auth\Login;
 use Modules\Auth\Livewire\Auth\Register;
 use Modules\Auth\Livewire\Auth\ResetPassword;
 use Modules\Auth\Livewire\Auth\VerifyEmail;
 
-Route::middleware('guest')->group(function () {
-	Route::get('login', Login::class)
-		 ->name('login');
-
-    /*Route::get('register', Register::class)
+/*Route::middleware('guest')->group(function () {
+    Route::get('register', Register::class)
          ->name('register');
 
     Route::get('forgot-password', ForgotPassword::class)
          ->name('password.request');
 
     Route::get('reset-password/{token}', ResetPassword::class)
-         ->name('password.reset');*/
+         ->name('password.reset');
 });
 
-/*Route::middleware('auth')->group(function () {
-	Route::get('verify-email', VerifyEmail::class)
-		 ->name('verification.notice');
+Route::middleware('auth')->group(function () {
+    Route::get('verify-email', VerifyEmail::class)
+         ->name('verification.notice');
 
-	Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-		 ->middleware(['signed', 'throttle:6,1'])
-		 ->name('verification.verify');
+    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
+         ->middleware(['signed', 'throttle:6,1'])
+         ->name('verification.verify');
 
-	Route::get('confirm-password', ConfirmPassword::class)
-		 ->name('password.confirm');
+    Route::get('confirm-password', ConfirmPassword::class)
+         ->name('password.confirm');
 });*/
 
-Route::post('logout', App\Livewire\Actions\Logout::class)
-	 ->name('logout');
+Route::post('logout', Logout::class)
+    ->name('logout');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('auths', AuthController::class)->names('auth');

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'ssr' => [
+        'enabled' => (bool) env('INERTIA_SSR_ENABLED', true),
+        'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
+        'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),
+    ],
+
+    /*
+    | Inertia's default page paths point at resource_path('js/Pages') (capital P).
+    | This project uses lowercase resources/js/pages/, which resolves on
+    | case-insensitive filesystems (macOS default) but fails on case-sensitive
+    | ones (Linux CI). Override both the runtime and testing view-finder paths
+    | to match the actual on-disk directory.
+    */
+    'page_paths' => [
+        resource_path('js/pages'),
+    ],
+
+    'page_extensions' => [
+        'tsx',
+        'jsx',
+        'ts',
+        'js',
+    ],
+
+    'testing' => [
+        'ensure_pages_exist' => true,
+        'page_paths' => [
+            resource_path('js/pages'),
+        ],
+        'page_extensions' => [
+            'tsx',
+            'jsx',
+            'ts',
+            'js',
+        ],
+    ],
+
+];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -66,6 +66,10 @@
     --color-info: #2962FF;
 
     /* Typography — families */
+    /* Override Tailwind v4's default --font-sans so the `font-sans` utility
+       (used by the Blade root <body>) and every unclassed text element
+       inherit Poppins instead of ui-sans-serif. */
+    --font-sans: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-display: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-body: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-ui: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;

--- a/resources/js/pages/Auth/Login.tsx
+++ b/resources/js/pages/Auth/Login.tsx
@@ -1,0 +1,105 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { Button, Checkbox, Input, Password } from '@artisanpack-ui/react/form';
+import type { FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+interface LoginProps {
+    status?: string | null;
+    canResetPassword: boolean;
+}
+
+type LoginForm = {
+    email: string;
+    password: string;
+    remember: boolean;
+};
+
+export default function Login({ status, canResetPassword }: LoginProps) {
+    const { data, setData, post, processing, errors, reset } = useForm<LoginForm>({
+        email: '',
+        password: '',
+        remember: false,
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/login', {
+            onFinish: () => reset('password'),
+        });
+    };
+
+    return (
+        <AuthLayout
+            title="Log in to your account"
+            description="Enter your email and password below to log in"
+        >
+            <Head title="Log in" />
+
+            {status ? (
+                <div
+                    role="status"
+                    className="mb-4 text-center text-small text-success"
+                >
+                    {status}
+                </div>
+            ) : null}
+
+            <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    label="Email address"
+                    autoComplete="email"
+                    autoFocus
+                    required
+                    placeholder="email@example.com"
+                    value={data.email}
+                    onChange={(event) => setData('email', event.target.value)}
+                    error={errors.email}
+                />
+
+                <div className="flex flex-col gap-2">
+                    <Password
+                        id="password"
+                        name="password"
+                        label="Password"
+                        autoComplete="current-password"
+                        required
+                        placeholder="Password"
+                        value={data.password}
+                        onChange={(event) => setData('password', event.target.value)}
+                        error={errors.password}
+                    />
+                    {canResetPassword ? (
+                        <Link
+                            href="/forgot-password"
+                            className="self-end text-small text-text-muted underline hover:text-text"
+                        >
+                            Forgot your password?
+                        </Link>
+                    ) : null}
+                </div>
+
+                <Checkbox
+                    id="remember"
+                    name="remember"
+                    label="Remember me"
+                    checked={data.remember}
+                    onChange={(event) => setData('remember', event.target.checked)}
+                />
+
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Log in
+                </Button>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,3 +1,16 @@
 <?php
 
+declare(strict_types=1);
 
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Laravel\Fortify\Features;
+
+Route::middleware('guest')->group(function () {
+    Route::get('login', function () {
+        return Inertia::render('Auth/Login', [
+            'canResetPassword' => Features::enabled(Features::resetPasswords()),
+            'status' => session('status'),
+        ]);
+    })->name('login');
+});

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,43 +1,44 @@
 <?php
 
-use App\Models\User;
-use Livewire\Livewire;
-use Modules\Auth\Livewire\Auth\Login as LoginComponent;
+declare(strict_types=1);
 
-it('login screen can be rendered', function () {
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+
+it('renders the Inertia login page at /login', function () {
     $response = $this->get(route('login'));
 
-    $response->assertStatus(200);
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/Login')
+        ->where('canResetPassword', true)
+        ->has('status')
+    );
 });
 
-it('users can log in', function () {
-    $user = User::factory()->create([
-        'password' => bcrypt('password'),
+it('logs users in via the Fortify POST /login action', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post(route('login'), [
+        'email' => $user->email,
+        'password' => 'password',
+        'remember' => false,
     ]);
 
-    Livewire::test(LoginComponent::class)
-        ->set('email', $user->email)
-        ->set('password', 'password')
-        ->set('remember', false)
-        ->call('login')
-        ->assertHasNoErrors()
-        ->assertRedirect(route('dashboard', absolute: false));
-
+    $response->assertRedirect(config('fortify.home'));
     $this->assertAuthenticatedAs($user);
 });
 
-it('users can not authenticate with invalid password', function () {
-    $user = User::factory()->create([
-        'password' => bcrypt('password'),
+it('rejects invalid credentials with a validation error on email', function () {
+    $user = User::factory()->create();
+
+    $response = $this->from(route('login'))->post(route('login'), [
+        'email' => $user->email,
+        'password' => 'wrong-password',
     ]);
 
-    Livewire::test(LoginComponent::class)
-        ->set('email', $user->email)
-        ->set('password', 'wrong-password')
-        ->set('remember', false)
-        ->call('login')
-        ->assertHasErrors('email');
-
+    $response->assertRedirect(route('login'));
+    $response->assertSessionHasErrors('email');
     $this->assertGuest();
 });
 
@@ -47,6 +48,5 @@ it('users can logout', function () {
     $response = $this->actingAs($user)->post(route('logout'));
 
     $response->assertRedirect(route('home'));
-
     $this->assertGuest();
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,15 @@ const moduleAssets = globSync(
 );
 
 export default defineConfig({
+    // In dev, Vite serves resources/css/app.css from its own origin
+    // (https://<host>:5173), so `url('/fonts/…')` inside that CSS resolves
+    // against Vite — not Laravel. Point publicDir at Laravel's public/ so
+    // Vite's built-in static handler serves those assets in dev; disable
+    // copyPublicDir so the build doesn't duplicate them into public/build/.
+    publicDir: 'public',
+    build: {
+        copyPublicDir: false,
+    },
     plugins: [
         laravel({
             input: [


### PR DESCRIPTION
## Summary

Ports `/login` from the v2 Livewire component (`Modules/Auth/Livewire/Auth/Login`) to an Inertia + React page wired through Fortify's POST `/login` action. First real Inertia page render, so it also cleans up two dev-QA gaps that only surfaced here (Vite dev fonts + default `font-sans` mapping).

Plan reference: V2_REFACTOR_PLAN.md §9.2 item #12.

## Related Issue

Closes #76

## Type of Change

- [x] New feature

## Changes

- `routes/auth.php`: register a guest-middleware `Route::get('login', …)` that returns `Inertia::render('Auth/Login', ['canResetPassword' => …, 'status' => …])`.
- `resources/js/pages/Auth/Login.tsx`: React page using `@artisanpack-ui/react` `Input`/`Password`/`Checkbox`/`Button` + Inertia `useForm`. Renders inside the shared `AuthLayout` (aurora background + centered card).
- `Modules/Auth/routes/web.php`: drop the Livewire `/login` route registration and merge the leftover empty `guest` group into the sibling commented block. The Livewire component itself stays until §9.2 item #17 removes the module.
- `tests/Feature/Auth/LoginTest.php`: rewrite for the Inertia flow — `AssertableInertia` render assertion, Fortify POST for success/failure paths, existing logout test unchanged.
- `vite.config.js`: set `publicDir: 'public'` + `build.copyPublicDir: false`. Vite dev serves CSS from `:5173`, so `url('/fonts/…')` inside app.css resolved against Vite (which didn't serve `public/`) and 404'd. Pointing Vite's publicDir at Laravel's public/ makes the built-in static handler serve those assets in dev; `copyPublicDir: false` keeps the build from duplicating them into `public/build/`.
- `resources/css/app.css`: register `--font-sans` in `@theme` so the default `font-sans` utility (used by the Blade root `<body>`) and every unclassed text element inherit Poppins. Previously only elements with an explicit `font-display` class rendered in Poppins.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

New Pest coverage (`tests/Feature/Auth/LoginTest.php`):
- Renders `Auth/Login` via `AssertableInertia` with the expected props.
- Logs users in via Fortify POST `/login` → redirects to `config('fortify.home')`.
- Invalid credentials redirect back to `/login` with a validation error on `email`.
- Logout still works.

Full suite: 219 passing (712 assertions). TypeScript typecheck clean. Pint clean.

Manually verified in Herd:
- `/login` renders with Poppins throughout.
- Wrong credentials → error under email field.
- Right credentials → `/dashboard`.
- Dark mode looks right.
- `/fonts/poppins/*.woff2` serve 200 from Vite dev.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)