### PR TITLE
feat: add Inertia email verification screens

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -4,11 +4,13 @@ namespace App\Providers;
 
 use App\Actions\Fortify\ResetUserPassword;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Contracts\VerifyEmailResponse;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -18,7 +20,18 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->instance(
+            VerifyEmailResponse::class,
+            new class implements VerifyEmailResponse
+            {
+                public function toResponse($request)
+                {
+                    return $request->wantsJson()
+                        ? new JsonResponse('', 204)
+                        : redirect()->intended(route('verification.verified'));
+                }
+            }
+        );
     }
 
     /**

--- a/resources/js/pages/Auth/Verified.tsx
+++ b/resources/js/pages/Auth/Verified.tsx
@@ -1,0 +1,29 @@
+import { Head, router } from '@inertiajs/react';
+import { Button } from '@artisanpack-ui/react/form';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+export default function Verified() {
+    return (
+        <AuthLayout
+            title="Email verified"
+            description="Your email address has been successfully verified"
+        >
+            <Head title="Email verified" />
+
+            <p className="mb-6 text-small text-text-muted">
+                Thanks for confirming your email address. You now have full access to
+                your ArtisanPack UI account.
+            </p>
+
+            <Button
+                type="button"
+                color="primary"
+                className="w-full"
+                onClick={() => router.visit('/dashboard')}
+            >
+                Continue to dashboard
+            </Button>
+        </AuthLayout>
+    );
+}

--- a/resources/js/pages/Auth/VerifyEmail.tsx
+++ b/resources/js/pages/Auth/VerifyEmail.tsx
@@ -1,0 +1,63 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { Button } from '@artisanpack-ui/react/form';
+import type { FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+interface VerifyEmailProps {
+    status?: string | null;
+}
+
+export default function VerifyEmail({ status }: VerifyEmailProps) {
+    const { post, processing } = useForm({});
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/email/verification-notification');
+    };
+
+    return (
+        <AuthLayout
+            title="Verify your email address"
+            description="Check your inbox for a verification link before continuing"
+        >
+            <Head title="Verify email" />
+
+            {status === 'verification-link-sent' ? (
+                <div
+                    role="status"
+                    className="mb-4 text-center text-small text-success"
+                >
+                    A new verification link has been sent to your email address.
+                </div>
+            ) : null}
+
+            <p className="mb-6 text-small text-text-muted">
+                Thanks for signing up. Before getting started, please verify your email
+                address by clicking on the link we just sent to you. If you didn&rsquo;t
+                receive the email, we&rsquo;ll gladly send you another.
+            </p>
+
+            <form onSubmit={submit} className="flex flex-col gap-4" noValidate>
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Resend verification email
+                </Button>
+
+                <Link
+                    href="/logout"
+                    method="post"
+                    as="button"
+                    className="self-center text-small text-text-muted underline hover:text-text"
+                >
+                    Log out
+                </Link>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -14,3 +14,15 @@ Route::middleware('guest')->group(function () {
         ]);
     })->name('login');
 });
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('email/verify', function () {
+        return Inertia::render('Auth/VerifyEmail', [
+            'status' => session('status'),
+        ]);
+    })->name('verification.notice');
+
+    Route::get('verified', function () {
+        return Inertia::render('Auth/Verified');
+    })->middleware('verified')->name('verification.verified');
+});

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Inertia\Testing\AssertableInertia;
+
+it('renders the Inertia verify-email notice page for unverified users', function () {
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->actingAs($user)->get(route('verification.notice'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/VerifyEmail')
+        ->has('status')
+    );
+});
+
+it('redirects guests away from the verification notice page', function () {
+    $response = $this->get(route('verification.notice'));
+
+    $response->assertRedirect(route('login'));
+});
+
+it('resends the verification email via Fortify POST /email/verification-notification', function () {
+    Notification::fake();
+
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->actingAs($user)
+        ->from(route('verification.notice'))
+        ->post('/email/verification-notification');
+
+    $response->assertRedirect(route('verification.notice'));
+    $response->assertSessionHas('status', 'verification-link-sent');
+    Notification::assertSentTo($user, VerifyEmail::class);
+});
+
+it('marks the user as verified when the signed verification link is visited', function () {
+    Event::fake();
+
+    $user = User::factory()->unverified()->create();
+
+    $verifyUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->getKey(), 'hash' => sha1($user->getEmailForVerification())]
+    );
+
+    $response = $this->actingAs($user)->get($verifyUrl);
+
+    $response->assertRedirect(route('verification.verified'));
+    Event::assertDispatched(Verified::class);
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+});
+
+it('renders the Inertia verified callback page after verification succeeds', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('verification.verified'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/Verified')
+    );
+});
+
+it('blocks access to the verified callback page for unverified users', function () {
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->actingAs($user)->get(route('verification.verified'));
+
+    $response->assertRedirect(route('verification.notice'));
+});


### PR DESCRIPTION
## Summary

Ports Fortify's email verification flow to Inertia + React with AP-UI form components. Adds a verify-notice screen at `/email/verify` and a verified-callback screen at `/verified` shown after a successful verification link click.

## Related Issue

Closes #77

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- Register `verification.notice` (`GET /email/verify`) as an Inertia route rendering `Auth/VerifyEmail`, since `fortify.views = false` skips Fortify's built-in view route.
- Register `verification.verified` (`GET /verified`, `auth`+`verified` middleware) rendering `Auth/Verified` as the post-verification landing page.
- Bind `Laravel\Fortify\Contracts\VerifyEmailResponse` in `FortifyServiceProvider::register()` to redirect through `verification.verified` (preserves `intended()` and returns 204 for XHR).
- Add `resources/js/pages/Auth/VerifyEmail.tsx` — AP-UI card with resend button (POSTs to `/email/verification-notification`) and logout link. Displays the `verification-link-sent` status flash.
- Add `resources/js/pages/Auth/Verified.tsx` — AP-UI card confirming verification with a "Continue to dashboard" button that calls `router.visit('/dashboard')`.

## Testing

- [x] Tests added or updated — 6 Pest feature tests in `tests/Feature/Auth/EmailVerificationTest.php` covering notice render, guest gate, resend + notification dispatch, signed-link verify redirect, callback render, and unverified block on the callback.
- [x] Manually tested locally — logged in as an unverified user, resent link, clicked the signed URL in the log, and confirmed landing on `/verified` and successful navigation to `/dashboard`.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass (all 19 auth tests green)
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)