### PR TITLE
feat: 2FA management screens (enable, confirm, recovery codes, challenge)

### DIFF
--- a/app/Http/Controllers/Settings/TwoFactorController.php
+++ b/app/Http/Controllers/Settings/TwoFactorController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TwoFactorController extends Controller
+{
+    /**
+     * Show the two-factor authentication settings page.
+     */
+    public function show(Request $request): Response
+    {
+        $user = $request->user();
+
+        $enabled = ! is_null($user->two_factor_secret);
+        $confirmed = ! is_null($user->two_factor_confirmed_at);
+
+        return Inertia::render('Settings/TwoFactor', [
+            'enabled' => $enabled,
+            'confirmed' => $confirmed,
+            'qrCodeSvg' => ($enabled && ! $confirmed) ? $user->twoFactorQrCodeSvg() : null,
+            'secretKey' => ($enabled && ! $confirmed) ? Crypt::decrypt($user->two_factor_secret) : null,
+            'recoveryCodes' => $confirmed ? $user->recoveryCodes() : [],
+            'status' => $request->session()->get('status'),
+        ]);
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -9,7 +9,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Inertia\Inertia;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\VerifyEmailResponse;
 use Laravel\Fortify\Fortify;
 
@@ -29,6 +32,44 @@ class FortifyServiceProvider extends ServiceProvider
                     return $request->wantsJson()
                         ? new JsonResponse('', 204)
                         : redirect()->intended(route('verification.verified'));
+                }
+            }
+        );
+
+        $this->app->instance(
+            LoginResponse::class,
+            new class implements LoginResponse
+            {
+                public function toResponse($request)
+                {
+                    if ($request->wantsJson()) {
+                        return new JsonResponse(['two_factor' => false]);
+                    }
+
+                    $target = redirect()->intended(Fortify::redirects('login'))->getTargetUrl();
+
+                    return $request->header('X-Inertia')
+                        ? Inertia::location($target)
+                        : redirect()->to($target);
+                }
+            }
+        );
+
+        $this->app->instance(
+            TwoFactorLoginResponse::class,
+            new class implements TwoFactorLoginResponse
+            {
+                public function toResponse($request)
+                {
+                    if ($request->wantsJson()) {
+                        return new JsonResponse('', 204);
+                    }
+
+                    $target = redirect()->intended(Fortify::redirects('login'))->getTargetUrl();
+
+                    return $request->header('X-Inertia')
+                        ? Inertia::location($target)
+                        : redirect()->to($target);
                 }
             }
         );

--- a/resources/js/pages/Auth/ConfirmPassword.tsx
+++ b/resources/js/pages/Auth/ConfirmPassword.tsx
@@ -1,0 +1,55 @@
+import { Head, useForm } from '@inertiajs/react';
+import { Button, Password } from '@artisanpack-ui/react/form';
+import type { FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+type ConfirmForm = {
+    password: string;
+};
+
+export default function ConfirmPassword() {
+    const { data, setData, post, processing, errors, reset } = useForm<ConfirmForm>({
+        password: '',
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/user/confirm-password', {
+            onFinish: () => reset('password'),
+        });
+    };
+
+    return (
+        <AuthLayout
+            title="Confirm your password"
+            description="This is a secure area — confirm your password before continuing"
+        >
+            <Head title="Confirm password" />
+
+            <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                <Password
+                    id="password"
+                    name="password"
+                    label="Password"
+                    autoComplete="current-password"
+                    autoFocus
+                    required
+                    value={data.password}
+                    onChange={(event) => setData('password', event.target.value)}
+                    error={errors.password}
+                />
+
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Confirm
+                </Button>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/resources/js/pages/Auth/TwoFactorChallenge.tsx
+++ b/resources/js/pages/Auth/TwoFactorChallenge.tsx
@@ -1,0 +1,93 @@
+import { Head, useForm } from '@inertiajs/react';
+import { Button, Input, Pin } from '@artisanpack-ui/react/form';
+import { useState, type FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+type ChallengeForm = {
+    code: string;
+    recovery_code: string;
+};
+
+export default function TwoFactorChallenge() {
+    const [useRecovery, setUseRecovery] = useState(false);
+    const { data, setData, post, processing, errors, reset } = useForm<ChallengeForm>({
+        code: '',
+        recovery_code: '',
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/two-factor-challenge', {
+            onFinish: () => reset('code', 'recovery_code'),
+        });
+    };
+
+    const toggleMode = () => {
+        if (useRecovery) {
+            setData('recovery_code', '');
+        } else {
+            setData('code', '');
+        }
+        setUseRecovery((previous) => !previous);
+    };
+
+    return (
+        <AuthLayout
+            title="Two-factor authentication"
+            description={
+                useRecovery
+                    ? 'Enter one of your unused recovery codes to continue'
+                    : 'Enter the six-digit code from your authenticator app'
+            }
+        >
+            <Head title="Two-factor authentication" />
+
+            <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                {useRecovery ? (
+                    <Input
+                        id="recovery_code"
+                        name="recovery_code"
+                        label="Recovery code"
+                        autoComplete="one-time-code"
+                        autoFocus
+                        required
+                        value={data.recovery_code}
+                        onChange={(event) => setData('recovery_code', event.target.value)}
+                        error={errors.recovery_code}
+                    />
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        <span className="text-small text-text-muted">Authentication code</span>
+                        <Pin
+                            length={6}
+                            numeric
+                            autoFocus
+                            value={data.code}
+                            onValueChange={(value) => setData('code', value)}
+                            error={errors.code}
+                        />
+                    </div>
+                )}
+
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Log in
+                </Button>
+
+                <button
+                    type="button"
+                    onClick={toggleMode}
+                    className="self-center text-small text-text-muted underline hover:text-text"
+                >
+                    {useRecovery ? 'Use an authentication code' : 'Use a recovery code'}
+                </button>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/resources/js/pages/Settings/TwoFactor.tsx
+++ b/resources/js/pages/Settings/TwoFactor.tsx
@@ -1,0 +1,233 @@
+import { Head, router, useForm } from '@inertiajs/react';
+import { Button, Pin } from '@artisanpack-ui/react/form';
+import { Card } from '@artisanpack-ui/react/layout';
+import { Alert } from '@artisanpack-ui/react/feedback';
+import { useState, type FormEventHandler } from 'react';
+
+import { AdminLayout } from '../../layouts/AdminLayout';
+
+interface TwoFactorProps {
+    enabled: boolean;
+    confirmed: boolean;
+    qrCodeSvg: string | null;
+    secretKey: string | null;
+    recoveryCodes: string[];
+    status?: string | null;
+}
+
+type ConfirmForm = {
+    code: string;
+};
+
+export default function TwoFactor({
+    enabled,
+    confirmed,
+    qrCodeSvg,
+    secretKey,
+    recoveryCodes,
+    status,
+}: TwoFactorProps) {
+    const [showingRecovery, setShowingRecovery] = useState(false);
+
+    const confirmForm = useForm<ConfirmForm>({ code: '' });
+    const enableForm = useForm({});
+    const disableForm = useForm({});
+    const regenerateForm = useForm({});
+
+    const enable: FormEventHandler = (event) => {
+        event.preventDefault();
+        enableForm.post('/user/two-factor-authentication', {
+            preserveScroll: true,
+        });
+    };
+
+    const confirm: FormEventHandler = (event) => {
+        event.preventDefault();
+        confirmForm.post('/user/confirmed-two-factor-authentication', {
+            preserveScroll: true,
+            onSuccess: () => confirmForm.reset('code'),
+        });
+    };
+
+    const disable = () => {
+        disableForm.delete('/user/two-factor-authentication', {
+            preserveScroll: true,
+            onSuccess: () => setShowingRecovery(false),
+        });
+    };
+
+    const regenerate = () => {
+        regenerateForm.post('/user/two-factor-recovery-codes', {
+            preserveScroll: true,
+            onSuccess: () => router.reload({ only: ['recoveryCodes'] }),
+        });
+    };
+
+    return (
+        <AdminLayout title="Two-factor authentication">
+            <Head title="Two-factor authentication" />
+
+            <div className="mx-auto w-full max-w-3xl">
+                <header className="mb-8">
+                    <p className="text-small text-text-muted">
+                        Add an extra layer of security by requiring a code from your
+                        authenticator app when you sign in.
+                    </p>
+                </header>
+
+                {status ? (
+                    <Alert color="success" className="mb-6">
+                        {status}
+                    </Alert>
+                ) : null}
+
+                <Card>
+                    {!enabled ? (
+                        <div className="flex flex-col gap-4">
+                            <p className="text-small text-text-muted">
+                                Two-factor authentication is not enabled. Enable it to
+                                secure your account with an authenticator app.
+                            </p>
+                            <form onSubmit={enable}>
+                                <Button
+                                    type="submit"
+                                    color="primary"
+                                    loading={enableForm.processing}
+                                >
+                                    Enable two-factor authentication
+                                </Button>
+                            </form>
+                        </div>
+                    ) : !confirmed ? (
+                        <div className="flex flex-col gap-6">
+                            <div>
+                                <h2 className="font-display text-h6">Finish setting up</h2>
+                                <p className="mt-2 text-small text-text-muted">
+                                    Scan the QR code below with your authenticator app,
+                                    then enter the six-digit code it generates to finish
+                                    enabling two-factor authentication.
+                                </p>
+                            </div>
+
+                            {qrCodeSvg ? (
+                                <div
+                                    className="rounded-box bg-surface p-4"
+                                    dangerouslySetInnerHTML={{ __html: qrCodeSvg }}
+                                />
+                            ) : null}
+
+                            {secretKey ? (
+                                <div>
+                                    <p className="text-small text-text-muted">
+                                        Or enter this setup key manually:
+                                    </p>
+                                    <code className="mt-1 block break-all rounded-box bg-surface px-3 py-2 font-mono text-small">
+                                        {secretKey}
+                                    </code>
+                                </div>
+                            ) : null}
+
+                            <form onSubmit={confirm} className="flex flex-col gap-4">
+                                <div className="flex flex-col gap-2">
+                                    <span className="text-small text-text-muted">
+                                        Authentication code
+                                    </span>
+                                    <Pin
+                                        length={6}
+                                        numeric
+                                        autoFocus
+                                        value={confirmForm.data.code}
+                                        onValueChange={(value) =>
+                                            confirmForm.setData('code', value)
+                                        }
+                                        error={confirmForm.errors.code}
+                                    />
+                                </div>
+
+                                <div className="flex flex-wrap gap-3">
+                                    <Button
+                                        type="submit"
+                                        color="primary"
+                                        loading={confirmForm.processing}
+                                    >
+                                        Confirm
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        color="ghost"
+                                        onClick={disable}
+                                        loading={disableForm.processing}
+                                    >
+                                        Cancel
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-6">
+                            <Alert color="success">
+                                Two-factor authentication is enabled on your account.
+                            </Alert>
+
+                            <div>
+                                <h2 className="font-display text-h6">Recovery codes</h2>
+                                <p className="mt-2 text-small text-text-muted">
+                                    Store these recovery codes in a secure password
+                                    manager. They can be used to sign in if you lose
+                                    access to your authenticator device.
+                                </p>
+
+                                <div className="mt-3 flex flex-wrap gap-3">
+                                    <Button
+                                        type="button"
+                                        color="secondary"
+                                        onClick={() =>
+                                            setShowingRecovery((previous) => !previous)
+                                        }
+                                    >
+                                        {showingRecovery
+                                            ? 'Hide recovery codes'
+                                            : 'Show recovery codes'}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        color="ghost"
+                                        onClick={regenerate}
+                                        loading={regenerateForm.processing}
+                                    >
+                                        Regenerate codes
+                                    </Button>
+                                </div>
+
+                                {showingRecovery && recoveryCodes.length > 0 ? (
+                                    <ul className="mt-4 grid grid-cols-1 gap-2 rounded-box bg-surface p-4 font-mono text-small sm:grid-cols-2">
+                                        {recoveryCodes.map((code) => (
+                                            <li key={code}>{code}</li>
+                                        ))}
+                                    </ul>
+                                ) : null}
+                            </div>
+
+                            <div>
+                                <h2 className="font-display text-h6">Disable</h2>
+                                <p className="mt-2 text-small text-text-muted">
+                                    Turning off two-factor authentication will remove
+                                    the requirement to enter a code when you sign in.
+                                </p>
+                                <Button
+                                    type="button"
+                                    color="error"
+                                    className="mt-3"
+                                    onClick={disable}
+                                    loading={disableForm.processing}
+                                >
+                                    Disable two-factor authentication
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </Card>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -13,6 +13,14 @@ Route::middleware('guest')->group(function () {
             'status' => session('status'),
         ]);
     })->name('login');
+
+    Route::get('two-factor-challenge', function () {
+        if (! session()->has('login.id')) {
+            return redirect()->route('login');
+        }
+
+        return Inertia::render('Auth/TwoFactorChallenge');
+    })->name('two-factor.login');
 });
 
 Route::middleware(['auth'])->group(function () {
@@ -25,4 +33,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('verified', function () {
         return Inertia::render('Auth/Verified');
     })->middleware('verified')->name('verification.verified');
+
+    Route::get('user/confirm-password', function () {
+        return Inertia::render('Auth/ConfirmPassword');
+    })->name('password.confirm');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\TwoFactorController;
 use App\Http\Controllers\SitemapController;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
@@ -12,6 +13,9 @@ Route::middleware(['auth'])->group(function () {
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
     Volt::route('settings/password', 'settings.password')->name('settings.password');
     Volt::route('settings/appearance', 'settings.appearance')->name('settings.appearance');
+
+    Route::get('dashboard/settings/two-factor', [TwoFactorController::class, 'show'])
+        ->name('dashboard.settings.two-factor');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/Auth/ConfirmPasswordTest.php
+++ b/tests/Feature/Auth/ConfirmPasswordTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+
+it('renders the password confirmation page for authenticated users', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('password.confirm'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/ConfirmPassword')
+    );
+});
+
+it('redirects guests to the login page', function () {
+    $response = $this->get(route('password.confirm'));
+
+    $response->assertRedirect(route('login'));
+});
+
+it('confirms the password via Fortify POST /user/confirm-password', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/user/confirm-password', [
+        'password' => 'password',
+    ]);
+
+    $response->assertRedirect();
+    expect(session('auth.password_confirmed_at'))->not->toBeNull();
+});

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -42,6 +42,19 @@ it('rejects invalid credentials with a validation error on email', function () {
     $this->assertGuest();
 });
 
+it('returns an Inertia external redirect when logging in from an Inertia request', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post(route('login'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ], ['X-Inertia' => 'true', 'X-Requested-With' => 'XMLHttpRequest']);
+
+    $response->assertStatus(409);
+    $response->assertHeader('X-Inertia-Location', url(config('fortify.home')));
+    $this->assertAuthenticatedAs($user);
+});
+
 it('users can logout', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Auth/TwoFactorChallengeTest.php
+++ b/tests/Feature/Auth/TwoFactorChallengeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+
+it('renders the two-factor challenge page when a login is in progress', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->withSession(['login.id' => $user->getKey(), 'login.remember' => false])
+        ->get(route('two-factor.login'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/TwoFactorChallenge')
+    );
+});
+
+it('redirects to the login page when no login is in progress', function () {
+    $response = $this->get(route('two-factor.login'));
+
+    $response->assertRedirect(route('login'));
+});
+
+it('returns an Inertia external redirect after a successful two-factor challenge', function () {
+    $user = User::factory()->create([
+        'two_factor_secret' => encrypt(app(TwoFactorAuthenticationProvider::class)->generateSecretKey()),
+        'two_factor_recovery_codes' => encrypt(json_encode(['recovery-abc-123'])),
+        'two_factor_confirmed_at' => now(),
+    ]);
+
+    $response = $this
+        ->withSession(['login.id' => $user->getKey(), 'login.remember' => false])
+        ->post('/two-factor-challenge', [
+            'recovery_code' => 'recovery-abc-123',
+        ], ['X-Inertia' => 'true', 'X-Requested-With' => 'XMLHttpRequest']);
+
+    $response->assertStatus(409);
+    $response->assertHeader('X-Inertia-Location', url(config('fortify.home')));
+    $this->assertAuthenticatedAs($user);
+});

--- a/tests/Feature/Settings/TwoFactorTest.php
+++ b/tests/Feature/Settings/TwoFactorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
+use Inertia\Testing\AssertableInertia;
+
+function confirmPassword(): void
+{
+    session()->put('auth.password_confirmed_at', time());
+}
+
+it('renders the two-factor settings page with disabled state for new users', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.two-factor'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Settings/TwoFactor')
+        ->where('enabled', false)
+        ->where('confirmed', false)
+        ->where('qrCodeSvg', null)
+        ->where('secretKey', null)
+        ->where('recoveryCodes', [])
+    );
+});
+
+it('renders the QR code and secret when two-factor is enabled but not confirmed', function () {
+    $user = User::factory()->create([
+        'two_factor_secret' => Crypt::encrypt('SECRET-KEY-VALUE'),
+        'two_factor_recovery_codes' => Crypt::encrypt(json_encode(['code-a', 'code-b'])),
+        'two_factor_confirmed_at' => null,
+    ]);
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.two-factor'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Settings/TwoFactor')
+        ->where('enabled', true)
+        ->where('confirmed', false)
+        ->where('secretKey', 'SECRET-KEY-VALUE')
+        ->where('recoveryCodes', [])
+        ->has('qrCodeSvg')
+    );
+});
+
+it('exposes recovery codes once two-factor is confirmed', function () {
+    $user = User::factory()->create([
+        'two_factor_secret' => Crypt::encrypt('SECRET-KEY-VALUE'),
+        'two_factor_recovery_codes' => Crypt::encrypt(json_encode(['code-a', 'code-b'])),
+        'two_factor_confirmed_at' => now(),
+    ]);
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.two-factor'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Settings/TwoFactor')
+        ->where('enabled', true)
+        ->where('confirmed', true)
+        ->where('qrCodeSvg', null)
+        ->where('secretKey', null)
+        ->where('recoveryCodes', ['code-a', 'code-b'])
+    );
+});
+
+it('redirects guests away from the two-factor settings page', function () {
+    $response = $this->get(route('dashboard.settings.two-factor'));
+
+    $response->assertRedirect(route('login'));
+});
+
+it('enables two-factor authentication via Fortify', function () {
+    $user = User::factory()->create();
+    confirmPassword();
+
+    $response = $this->actingAs($user)->post('/user/two-factor-authentication');
+
+    $response->assertRedirect();
+    expect($user->fresh()->two_factor_secret)->not->toBeNull();
+    expect($user->fresh()->two_factor_confirmed_at)->toBeNull();
+});
+
+it('regenerates recovery codes via Fortify', function () {
+    $user = User::factory()->create([
+        'two_factor_secret' => Crypt::encrypt('SECRET-KEY-VALUE'),
+        'two_factor_recovery_codes' => Crypt::encrypt(json_encode(['original-a', 'original-b'])),
+        'two_factor_confirmed_at' => now(),
+    ]);
+    confirmPassword();
+
+    $response = $this->actingAs($user)->post('/user/two-factor-recovery-codes');
+
+    $response->assertRedirect();
+    $codes = $user->fresh()->recoveryCodes();
+    expect($codes)->not->toEqual(['original-a', 'original-b']);
+    expect(count($codes))->toBe(8);
+});
+
+it('disables two-factor authentication via Fortify', function () {
+    $user = User::factory()->create([
+        'two_factor_secret' => Crypt::encrypt('SECRET-KEY-VALUE'),
+        'two_factor_recovery_codes' => Crypt::encrypt(json_encode(['code-a'])),
+        'two_factor_confirmed_at' => now(),
+    ]);
+    confirmPassword();
+
+    $response = $this->actingAs($user)->delete('/user/two-factor-authentication');
+
+    $response->assertRedirect();
+    expect($user->fresh()->two_factor_secret)->toBeNull();
+    expect($user->fresh()->two_factor_confirmed_at)->toBeNull();
+});


### PR DESCRIPTION
## Summary

Ports the Fortify 2FA UX to Inertia + React for the 3.0 refactor. Adds the login-time challenge, the settings management surface (enable → QR/confirm → recovery codes → regenerate/disable), and the password-confirmation gate Fortify requires when `confirmPassword: true` is set on the feature.

Also fixes an Inertia + still-Livewire-`/dashboard` interaction: Fortify's default `LoginResponse` and `TwoFactorLoginResponse` return a 302 to `fortify.home`, which Inertia's XHR follows and renders as an error modal. The bindings now return `Inertia::location()` (a 409 with `X-Inertia-Location`) for Inertia requests so the browser does a real full-page nav into the Livewire dashboard.

## Related Issue

Closes #78

## Type of Change

- [x] New feature

## Changes

- `resources/js/pages/Auth/TwoFactorChallenge.tsx` — 6-digit OTP `Pin` with a toggle to a recovery-code input; posts to `/two-factor-challenge`.
- `resources/js/pages/Auth/ConfirmPassword.tsx` — password re-entry gate; posts to `/user/confirm-password`.
- `resources/js/pages/Settings/TwoFactor.tsx` — three states in one page: disabled → enable button; enabled-not-confirmed → QR SVG + setup key + confirmation `Pin`; confirmed → success banner, show/hide recovery codes, regenerate, disable. Rendered inside `AdminLayout`.
- `app/Http/Controllers/Settings/TwoFactorController.php` — resolves 2FA state, calls Fortify's `twoFactorQrCodeSvg()` / `recoveryCodes()`, and only exposes the decrypted setup secret while 2FA is unconfirmed (so it stops flowing through the Inertia payload once activated).
- `app/Providers/FortifyServiceProvider.php` — binds `LoginResponse` and `TwoFactorLoginResponse` to emit `Inertia::location()` for Inertia requests.
- `routes/auth.php` — `GET /two-factor-challenge` (guest, `two-factor.login`), `GET /user/confirm-password` (auth, `password.confirm`).
- `routes/web.php` — `GET /dashboard/settings/two-factor` (auth, `dashboard.settings.two-factor`).

## Breaking Changes

None.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

New feature tests (13 total, all passing):

- `tests/Feature/Auth/TwoFactorChallengeTest.php` — page renders with `login.id` in session, redirects guests without it, and returns an Inertia external-redirect after a successful recovery-code challenge.
- `tests/Feature/Auth/ConfirmPasswordTest.php` — page renders for auth users, redirects guests, and confirms the password via Fortify.
- `tests/Feature/Auth/LoginTest.php` — added coverage that an Inertia login POST gets a 409 with `X-Inertia-Location: /dashboard`.
- `tests/Feature/Settings/TwoFactorTest.php` — three-state prop payloads (disabled / enabled-unconfirmed / confirmed) plus enable, regenerate, and disable round-trips through Fortify's endpoints.

Full suite: 239 passing.

Manual QA: walked login → dashboard nav, then `/dashboard/settings/two-factor` enable → QR scan → confirm → recovery codes → regenerate → disable.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

## Notes

- The `2026_07_23_183527_add_two_factor_columns_to_users_table` migration must run for this to work on any environment that hasn't already added those columns. On my local MySQL, an unrelated pending migration (`ai_usage_events`) was blocking the queue because the table already existed outside migrations; unblocking that is separate from this PR.
- `Modules\Admin\Livewire\SettingsPage` still owns `/dashboard/settings`; a link into `/dashboard/settings/two-factor` from that page can be wired up when Settings itself ports to Inertia (§9.2 item #16).