### PR TITLE
feat: add password reset Inertia screens

### DIFF
--- a/resources/js/pages/Auth/ForgotPassword.tsx
+++ b/resources/js/pages/Auth/ForgotPassword.tsx
@@ -1,0 +1,75 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { Button, Input } from '@artisanpack-ui/react/form';
+import type { FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+interface ForgotPasswordProps {
+    status?: string | null;
+}
+
+type ForgotPasswordForm = {
+    email: string;
+};
+
+export default function ForgotPassword({ status }: ForgotPasswordProps) {
+    const { data, setData, post, processing, errors } = useForm<ForgotPasswordForm>({
+        email: '',
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/forgot-password');
+    };
+
+    return (
+        <AuthLayout
+            title="Forgot your password?"
+            description="Enter your email and we'll send you a link to reset your password"
+        >
+            <Head title="Forgot password" />
+
+            {status ? (
+                <div
+                    role="status"
+                    className="mb-4 text-center text-small text-success"
+                >
+                    {status}
+                </div>
+            ) : null}
+
+            <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    label="Email address"
+                    autoComplete="email"
+                    autoFocus
+                    required
+                    placeholder="email@example.com"
+                    value={data.email}
+                    onChange={(event) => setData('email', event.target.value)}
+                    error={errors.email}
+                />
+
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Email password reset link
+                </Button>
+
+                <Link
+                    href="/login"
+                    className="self-center text-small text-text-muted underline hover:text-text"
+                >
+                    Back to log in
+                </Link>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/resources/js/pages/Auth/ResetPassword.tsx
+++ b/resources/js/pages/Auth/ResetPassword.tsx
@@ -1,0 +1,89 @@
+import { Head, useForm } from '@inertiajs/react';
+import { Button, Input, Password } from '@artisanpack-ui/react/form';
+import type { FormEventHandler } from 'react';
+
+import { AuthLayout } from '../../layouts/AuthLayout';
+
+interface ResetPasswordProps {
+    token: string;
+    email: string;
+}
+
+type ResetPasswordForm = {
+    token: string;
+    email: string;
+    password: string;
+    password_confirmation: string;
+};
+
+export default function ResetPassword({ token, email }: ResetPasswordProps) {
+    const { data, setData, post, processing, errors, reset } = useForm<ResetPasswordForm>({
+        token,
+        email,
+        password: '',
+        password_confirmation: '',
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+
+        post('/reset-password', {
+            onFinish: () => reset('password', 'password_confirmation'),
+        });
+    };
+
+    return (
+        <AuthLayout
+            title="Reset your password"
+            description="Choose a new password to regain access to your account"
+        >
+            <Head title="Reset password" />
+
+            <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    label="Email address"
+                    autoComplete="email"
+                    required
+                    value={data.email}
+                    onChange={(event) => setData('email', event.target.value)}
+                    error={errors.email}
+                />
+
+                <Password
+                    id="password"
+                    name="password"
+                    label="Password"
+                    autoComplete="new-password"
+                    autoFocus
+                    required
+                    value={data.password}
+                    onChange={(event) => setData('password', event.target.value)}
+                    error={errors.password}
+                />
+
+                <Password
+                    id="password_confirmation"
+                    name="password_confirmation"
+                    label="Confirm password"
+                    autoComplete="new-password"
+                    required
+                    value={data.password_confirmation}
+                    onChange={(event) => setData('password_confirmation', event.target.value)}
+                    error={errors.password_confirmation}
+                />
+
+                <Button
+                    type="submit"
+                    color="primary"
+                    className="w-full"
+                    loading={processing}
+                >
+                    Reset password
+                </Button>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
@@ -21,6 +22,19 @@ Route::middleware('guest')->group(function () {
 
         return Inertia::render('Auth/TwoFactorChallenge');
     })->name('two-factor.login');
+
+    Route::get('forgot-password', function () {
+        return Inertia::render('Auth/ForgotPassword', [
+            'status' => session('status'),
+        ]);
+    })->name('password.request');
+
+    Route::get('reset-password/{token}', function (string $token, Request $request) {
+        return Inertia::render('Auth/ResetPassword', [
+            'token' => $token,
+            'email' => (string) $request->query('email', ''),
+        ]);
+    })->name('password.reset');
 });
 
 Route::middleware(['auth'])->group(function () {

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,43 +1,81 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
-use Livewire\Livewire;
-use Modules\Auth\Livewire\Auth\ForgotPassword as ForgotPasswordComponent;
-use Modules\Auth\Livewire\Auth\ResetPassword as ResetPasswordComponent;
+use Inertia\Testing\AssertableInertia;
 
-test('reset password link can be requested', function () {
+it('renders the Inertia forgot-password page for guests', function () {
+    $response = $this->get(route('password.request'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/ForgotPassword')
+        ->has('status')
+    );
+});
+
+it('sends the password reset link via Fortify POST /forgot-password', function () {
     Notification::fake();
 
     $user = User::factory()->create();
 
-    Livewire::test(ForgotPasswordComponent::class)
-        ->set('email', $user->email)
-        ->call('sendPasswordResetLink')
-        ->assertHasNoErrors();
+    $response = $this->from(route('password.request'))
+        ->post('/forgot-password', ['email' => $user->email]);
 
+    $response->assertRedirect(route('password.request'));
+    $response->assertSessionHas('status');
     Notification::assertSentTo($user, ResetPassword::class);
 });
 
-test('password can be reset with valid token', function () {
+it('renders the Inertia reset-password page with token and email', function () {
+    $response = $this->get(route('password.reset', ['token' => 'test-token']).'?email=user@example.com');
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Auth/ResetPassword')
+        ->where('token', 'test-token')
+        ->where('email', 'user@example.com')
+    );
+});
+
+it('resets the password with a valid token', function () {
     Notification::fake();
 
     $user = User::factory()->create();
 
-    Livewire::test(ForgotPasswordComponent::class)
-        ->set('email', $user->email)
-        ->call('sendPasswordResetLink');
+    $this->from(route('password.request'))
+        ->post('/forgot-password', ['email' => $user->email]);
 
     Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
-        Livewire::test(ResetPasswordComponent::class, ['token' => $notification->token])
-            ->set('email', $user->email)
-            ->set('password', 'Str0ng-Passw0rd!')
-            ->set('password_confirmation', 'Str0ng-Passw0rd!')
-            ->call('resetPassword')
-            ->assertHasNoErrors()
-            ->assertRedirect(route('login', absolute: false));
+        $response = $this->post('/reset-password', [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'Str0ng-Passw0rd!',
+            'password_confirmation' => 'Str0ng-Passw0rd!',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('status');
 
         return true;
     });
+});
+
+it('rejects a password reset with an invalid token', function () {
+    $user = User::factory()->create();
+    $originalPassword = $user->password;
+
+    $response = $this->from(route('password.reset', ['token' => 'invalid-token']))
+        ->post('/reset-password', [
+            'token' => 'invalid-token',
+            'email' => $user->email,
+            'password' => 'Str0ng-Passw0rd!',
+            'password_confirmation' => 'Str0ng-Passw0rd!',
+        ]);
+
+    $response->assertSessionHasErrors('email');
+    expect($user->fresh()->password)->toBe($originalPassword);
 });


### PR DESCRIPTION
## Summary

Ports the password reset flow (request link + reset form) to Inertia + Fortify, matching the pattern used by Login, VerifyEmail, and the 2FA screens.

## Related Issue

Closes #79

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- Added `Auth/ForgotPassword` Inertia page — email input posting to Fortify's `/forgot-password`, with success status and "Back to log in" link.
- Added `Auth/ResetPassword` Inertia page — reset form (email, password, confirm) posting to `/reset-password`, with token/email hydrated from the URL.
- Registered guest-scoped `password.request` and `password.reset` view routes in `routes/auth.php` (Fortify views are disabled in config).
- Rewrote `tests/Feature/Auth/PasswordResetTest.php` for the Inertia + Fortify flow (5 tests): page render, link request, reset page render with token/email, successful reset, invalid-token rejection.

## Breaking Changes

None.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

Full `tests/Feature/Auth` suite passes (29 tests). Manually verified the end-to-end flow: request reset link from `/login` → email delivered → follow link → set new password → log in with new credentials.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)