### PR TITLE
test: preserve /documentation/{package}/changelog(s) 301 redirects

### DIFF
--- a/tests/Feature/DocumentationChangelogRedirectTest.php
+++ b/tests/Feature/DocumentationChangelogRedirectTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+it('301-redirects legacy /documentation/{package}/changelog(s) URLs to /changelogs/{package}', function (string $url, string $target) {
+    $this->get($url)
+        ->assertStatus(301)
+        ->assertRedirect($target);
+})->with([
+    'singular, known slug' => ['/documentation/test-package/changelog',     '/changelogs/test-package'],
+    'plural, known slug' => ['/documentation/test-package/changelogs',    '/changelogs/test-package'],
+    'singular, unknown slug' => ['/documentation/unknown-package/changelog',  '/changelogs/unknown-package'],
+    'plural, unknown slug' => ['/documentation/unknown-package/changelogs', '/changelogs/unknown-package'],
+]);


### PR DESCRIPTION
## Summary

The two redirect closures in `Modules/Packages/routes/web.php` that map the legacy 2.x URLs `/documentation/{package}/changelog` and `/documentation/{package}/changelogs` onto the current `/changelogs/{package}` route already ship byte-identical to 2.x (verified against commit `e5c64f9`). The only test coverage they had was `UrlMapSmokeTest`, which just asserts the final rendered page has no JS errors — nothing pinned the `301` status or the `Location` target, so an accidental change of the third `redirect()->route()` argument or of the destination route name would slip through.

This PR adds a Pest dataset test that locks both invariants in.

## Related Issue

Closes #86

## Type of Change

- [x] Bug fix (regression test — the routes themselves are unchanged)

## Changes

- Added `tests/Feature/DocumentationChangelogRedirectTest.php` — one dataset test, four rows: `{singular, plural} × {known slug, unknown slug}`, each asserting `301` + `Location: /changelogs/{package}`.

The redirect closures are pure string-in / string-out (no route-model binding), so no `Package` factory is needed and the unknown-slug rows are meaningful coverage — they prove the redirect fires at the routing layer regardless of DB state.

## Breaking Changes

None.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally (`curl -I` against `https://artisanpack-ui-docs.test/documentation/accessibility/changelog` and `/changelogs` both return `HTTP/2 301` with `location: https://artisanpack-ui-docs.test/changelogs/accessibility`)

`php artisan test tests/Feature/DocumentationChangelogRedirectTest.php` — 4 passed, 12 assertions.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (n/a)
- [ ] Changelog updated (n/a — no user-facing behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)