### PR TITLE
feat: React SearchOverlay with ⌘K trigger (#88)

### DIFF
--- a/Modules/Core/app/Http/Controllers/SearchController.php
+++ b/Modules/Core/app/Http/Controllers/SearchController.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Core\Services\IconResolverService;
+use Modules\Packages\Changelog;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
+use Modules\Pages\Page;
+
+/**
+ * JSON search endpoint that backs the React ⌘K SearchOverlay.
+ *
+ * Reproduces the shape of the legacy `mary-search-open` spotlight but
+ * emits icons in the same resolved-icon shape the sidebar consumes —
+ * `{type: 'class'|'svg', ...}` — so the React overlay can render them
+ * without piping raw Blade component tags through `dangerouslySetInnerHTML`
+ * the way the Livewire spotlight did.
+ */
+class SearchController extends Controller
+{
+    private const RESULT_LIMIT_PER_TYPE = 10;
+
+    public function __construct(protected IconResolverService $iconResolver) {}
+
+    public function search(Request $request): JsonResponse
+    {
+        $query = trim((string) $request->query('q', ''));
+
+        if ($query === '') {
+            return response()->json(['results' => []]);
+        }
+
+        $results = [
+            ...$this->pages($query),
+            ...$this->packages($query),
+            ...$this->documentation($query),
+            ...$this->changelogs($query),
+        ];
+
+        return response()->json(['results' => $results]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pages(string $query): array
+    {
+        return Page::query()
+            ->with('parentPage:id,title,slug')
+            ->where(function ($builder) use ($query): void {
+                $builder->where('title', 'like', "%{$query}%")
+                    ->orWhere('content', 'like', "%{$query}%");
+            })
+            ->limit(self::RESULT_LIMIT_PER_TYPE)
+            ->get()
+            ->map(function (Page $page): array {
+                $parent = $page->parentPage;
+
+                return [
+                    'id' => "page-{$page->id}",
+                    'name' => $page->title,
+                    'description' => $parent ? "Page · {$parent->title}" : 'Page',
+                    'link' => $parent
+                        ? route('page.child', ['parentSlug' => $parent->slug, 'slug' => $page->slug])
+                        : route('page.show', ['slug' => $page->slug]),
+                    'icon' => $this->iconResolver->resolve($page->icon ?: 'fas.file-lines'),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function packages(string $query): array
+    {
+        return Package::query()
+            ->where('name', 'like', "%{$query}%")
+            ->limit(self::RESULT_LIMIT_PER_TYPE)
+            ->get()
+            ->map(function (Package $package): ?array {
+                $link = $this->packageLink($package);
+
+                if ($link === null) {
+                    return null;
+                }
+
+                return [
+                    'id' => "package-{$package->id}",
+                    'name' => $package->name,
+                    'description' => 'Package',
+                    'link' => $link,
+                    'icon' => $this->iconResolver->resolve($package->icon ?: 'fas.cube'),
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Resolve the public-facing URL for a package result.
+     *
+     * Prefers the package's configured homepage doc, falls back to the
+     * first documentation entry by menu order. Returns null when the
+     * package has no publishable docs at all, so a result row that would
+     * dead-end on a 404 (or on the auth-guarded admin route) never ships
+     * back to the overlay.
+     */
+    protected function packageLink(Package $package): ?string
+    {
+        $homePage = $package->home();
+
+        if ($homePage !== null) {
+            return route('documentation.show', [
+                'package' => $package->slug,
+                'slug' => $homePage->slug,
+            ]);
+        }
+
+        $firstDoc = Documentation::where('package_id', $package->id)
+            ->orderBy('menu_order')
+            ->orderBy('id')
+            ->first(['slug']);
+
+        if ($firstDoc === null) {
+            return null;
+        }
+
+        return route('documentation.show', [
+            'package' => $package->slug,
+            'slug' => $firstDoc->slug,
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function documentation(string $query): array
+    {
+        return Documentation::query()
+            ->with('package:id,name,slug,icon')
+            ->where(function ($builder) use ($query): void {
+                $builder->where('title', 'like', "%{$query}%")
+                    ->orWhere('content', 'like', "%{$query}%");
+            })
+            ->limit(self::RESULT_LIMIT_PER_TYPE)
+            ->get()
+            ->map(function (Documentation $documentation): array {
+                $package = $documentation->package;
+
+                return [
+                    'id' => "documentation-{$documentation->id}",
+                    'name' => $documentation->title,
+                    'description' => "Documentation · {$package->name}",
+                    'link' => route('documentation.show', [
+                        'package' => $package->slug,
+                        'slug' => $documentation->slug,
+                    ]),
+                    'icon' => $this->iconResolver->resolve($package->icon ?: 'fas.book-open'),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function changelogs(string $query): array
+    {
+        return Changelog::query()
+            ->with('package:id,name,slug,icon')
+            ->where(function ($builder) use ($query): void {
+                $builder->where('title', 'like', "%{$query}%")
+                    ->orWhere('content', 'like', "%{$query}%");
+            })
+            ->limit(self::RESULT_LIMIT_PER_TYPE)
+            ->get()
+            ->map(function (Changelog $changelog): array {
+                $package = $changelog->package;
+
+                return [
+                    'id' => "changelog-{$changelog->id}",
+                    'name' => $changelog->title,
+                    'description' => "Changelog · {$package->name}",
+                    'link' => route('changelog.show', ['package' => $package->slug]),
+                    'icon' => $this->iconResolver->resolve($package->icon ?: 'fas.clipboard-list'),
+                ];
+            })
+            ->all();
+    }
+}

--- a/Modules/Core/resources/views/partials/header.blade.php
+++ b/Modules/Core/resources/views/partials/header.blade.php
@@ -6,15 +6,7 @@
             <span class="sr-only">ArtisanPack UI</span>
         </a>
 
-        {{-- Visual placeholder for the React SearchOverlay landing in #88. Hidden from AT until wired. --}}
-        <div class="flex-1 min-w-0 order-3 md:order-2 w-full md:w-auto" aria-hidden="true">
-            <x-artisanpack-input
-                :placeholder="__('Search...')"
-                icon="fas.magnifying-glass"
-                readonly
-                tabindex="-1"
-            />
-        </div>
+        {{-- Search moved to the React SearchOverlay (#88) that lives inside DocsLayout on every Inertia route. --}}
 
         <div class="flex items-center gap-2 md:gap-4 order-2 md:order-3">
             <x-artisanpack-theme-toggle class="btn btn-sm md:btn-md" />

--- a/Modules/Core/routes/web.php
+++ b/Modules/Core/routes/web.php
@@ -3,9 +3,11 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Core\Http\Controllers\CoreController;
 use Modules\Core\Http\Controllers\HomePageController;
+use Modules\Core\Http\Controllers\SearchController;
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('cores', CoreController::class)->names('core');
 });
 
 Route::get('/', [HomePageController::class, 'index'])->name('home');
+Route::get('/search', [SearchController::class, 'search'])->name('search');

--- a/resources/js/components/SearchOverlay.tsx
+++ b/resources/js/components/SearchOverlay.tsx
@@ -1,0 +1,343 @@
+import { router } from '@inertiajs/react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+export type SearchOverlayIcon = { type: 'svg'; markup: string } | { type: 'class'; class: string };
+
+export interface SearchOverlayResult {
+    id: string;
+    name: string;
+    description: string;
+    link: string;
+    icon: SearchOverlayIcon | null;
+}
+
+export interface SearchOverlayProps {
+    onClose: () => void;
+    endpoint?: string;
+    debounceMs?: number;
+}
+
+const DEFAULT_ENDPOINT = '/search';
+const DEFAULT_DEBOUNCE_MS = 250;
+
+/**
+ * Modal command palette that reproduces the legacy `mary-search-open`
+ * behavior against the same underlying data source (pages, packages,
+ * docs, changelogs) via the JSON `/search` endpoint.
+ *
+ * Mounted only when the overlay is open — the parent is expected to
+ * conditionally render this component so each opening starts from a
+ * fresh state without any explicit reset effect.
+ */
+export function SearchOverlay({
+    onClose,
+    endpoint = DEFAULT_ENDPOINT,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+}: SearchOverlayProps) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<SearchOverlayResult[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [searched, setSearched] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<HTMLUListElement>(null);
+    const abortRef = useRef<AbortController | null>(null);
+    const titleId = useId();
+
+    const trimmed = useMemo(() => query.trim(), [query]);
+
+    const close = useCallback(() => {
+        abortRef.current?.abort();
+        abortRef.current = null;
+        onClose();
+    }, [onClose]);
+
+    useEffect(() => {
+        const id = window.requestAnimationFrame(() => {
+            inputRef.current?.focus();
+        });
+        return () => window.cancelAnimationFrame(id);
+    }, []);
+
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                close();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [close]);
+
+    useEffect(() => {
+        if (trimmed === '') {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+            setLoading(true);
+
+            const url = `${endpoint}?q=${encodeURIComponent(trimmed)}`;
+            fetch(url, {
+                signal: controller.signal,
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+            })
+                .then(async (response) => {
+                    if (!response.ok) {
+                        throw new Error(`Search request failed: ${response.status}`);
+                    }
+                    const payload = (await response.json()) as {
+                        results?: SearchOverlayResult[];
+                    };
+                    // `abort()` cannot cancel a fetch whose response
+                    // already landed but hasn't run its `.then` yet, so
+                    // guard against a superseded controller writing stale
+                    // results over a newer query.
+                    if (abortRef.current !== controller) {
+                        return;
+                    }
+                    setResults(payload.results ?? []);
+                    setSearched(true);
+                    setActiveIndex(0);
+                })
+                .catch((error) => {
+                    if (error instanceof DOMException && error.name === 'AbortError') {
+                        return;
+                    }
+                    if (abortRef.current !== controller) {
+                        return;
+                    }
+                    setResults([]);
+                    setSearched(true);
+                })
+                .finally(() => {
+                    if (abortRef.current === controller) {
+                        setLoading(false);
+                        abortRef.current = null;
+                    }
+                });
+        }, debounceMs);
+
+        return () => window.clearTimeout(timer);
+    }, [trimmed, endpoint, debounceMs]);
+
+    const onQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const next = event.target.value;
+        setQuery(next);
+        if (next.trim() === '') {
+            abortRef.current?.abort();
+            abortRef.current = null;
+            setResults([]);
+            setSearched(false);
+            setLoading(false);
+        }
+    };
+
+    useEffect(
+        () => () => {
+            abortRef.current?.abort();
+            abortRef.current = null;
+        },
+        [],
+    );
+
+    const navigate = useCallback(
+        (result: SearchOverlayResult) => {
+            close();
+            router.visit(result.link);
+        },
+        [close],
+    );
+
+    const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'ArrowDown') {
+            if (results.length === 0) {
+                return;
+            }
+            event.preventDefault();
+            setActiveIndex((index) => (index + 1) % results.length);
+            return;
+        }
+        if (event.key === 'ArrowUp') {
+            if (results.length === 0) {
+                return;
+            }
+            event.preventDefault();
+            setActiveIndex((index) => (index - 1 + results.length) % results.length);
+            return;
+        }
+        if (event.key === 'Enter') {
+            const target = results[activeIndex];
+            if (!target) {
+                return;
+            }
+            event.preventDefault();
+            navigate(target);
+        }
+    };
+
+    useEffect(() => {
+        if (results.length === 0) {
+            return;
+        }
+        const list = listRef.current;
+        if (!list) {
+            return;
+        }
+        const active = list.querySelector<HTMLElement>(`[data-search-index="${activeIndex}"]`);
+        active?.scrollIntoView({ block: 'nearest' });
+    }, [activeIndex, results.length]);
+
+    const showEmpty = searched && !loading && results.length === 0 && trimmed !== '';
+    const showPrompt = trimmed === '' && !loading;
+
+    return (
+        <div
+            className="fixed inset-0 z-[70] flex items-start justify-center px-4 pt-[12vh]"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+        >
+            <button
+                type="button"
+                aria-label="Close search"
+                tabIndex={-1}
+                onClick={close}
+                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            />
+            <div
+                className="relative w-full max-w-2xl overflow-hidden rounded-[14px] border border-border-subtle bg-surface shadow-2xl"
+                style={{
+                    background: 'linear-gradient(180deg, #080C16 0%, #05070E 100%)',
+                }}
+            >
+                <div className="flex items-center gap-3 border-b border-border-subtle px-5 py-4">
+                    <i
+                        className="fa-solid fa-magnifying-glass text-[15px] text-text-subtle"
+                        aria-hidden
+                    />
+                    <input
+                        ref={inputRef}
+                        id={titleId}
+                        type="search"
+                        value={query}
+                        onChange={onQueryChange}
+                        onKeyDown={onInputKeyDown}
+                        placeholder="Search the docs…"
+                        aria-label="Search query"
+                        aria-autocomplete="list"
+                        aria-controls={`${titleId}-results`}
+                        autoComplete="off"
+                        spellCheck={false}
+                        className="min-w-0 flex-1 bg-transparent text-[16px] text-text placeholder:text-text-subtle focus:outline-none"
+                    />
+                    {loading ? (
+                        <span
+                            className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-border-subtle border-t-secondary"
+                            aria-label="Searching"
+                            role="status"
+                        />
+                    ) : (
+                        <kbd className="rounded-[5px] border border-border-subtle bg-surface-2 px-[7px] py-[2px] font-mono text-[11px] text-text-muted">
+                            Esc
+                        </kbd>
+                    )}
+                </div>
+
+                {showPrompt ? (
+                    <p className="px-5 py-6 text-small text-text-subtle">
+                        Type to search across pages, packages, docs, and changelogs.
+                    </p>
+                ) : null}
+
+                {showEmpty ? (
+                    <p className="px-5 py-6 text-small text-text-subtle">
+                        No matches for “{trimmed}”.
+                    </p>
+                ) : null}
+
+                {results.length > 0 ? (
+                    <ul
+                        ref={listRef}
+                        id={`${titleId}-results`}
+                        role="listbox"
+                        aria-label="Search results"
+                        className="max-h-[60vh] overflow-y-auto py-1"
+                    >
+                        {results.map((result, index) => (
+                            <li key={result.id} role="none">
+                                <button
+                                    type="button"
+                                    role="option"
+                                    aria-selected={index === activeIndex}
+                                    data-search-index={index}
+                                    onClick={() => navigate(result)}
+                                    onMouseEnter={() => setActiveIndex(index)}
+                                    className={`flex w-full items-center gap-3 px-5 py-3 text-left transition ${
+                                        index === activeIndex
+                                            ? 'bg-white/[0.06] text-text'
+                                            : 'text-text-muted hover:bg-white/[0.03] hover:text-text'
+                                    }`}
+                                >
+                                    <ResultIcon icon={result.icon} />
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block truncate text-[15px] font-semibold text-text">
+                                            {result.name}
+                                        </span>
+                                        <span className="block truncate text-[12px] text-text-subtle">
+                                            {result.description}
+                                        </span>
+                                    </span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function ResultIcon({ icon }: { icon: SearchOverlayIcon | null }) {
+    if (icon?.type === 'svg') {
+        return (
+            <span
+                aria-hidden
+                className="inline-flex h-5 w-5 items-center justify-center text-text-subtle"
+                dangerouslySetInnerHTML={{ __html: sizedSvg(icon.markup, 18) }}
+            />
+        );
+    }
+
+    const className = icon?.type === 'class' ? icon.class : 'fa-solid fa-file-lines';
+
+    return (
+        <i
+            aria-hidden
+            className={`${className} inline-flex h-5 w-5 items-center justify-center text-[15px] text-text-subtle`}
+        />
+    );
+}
+
+function sizedSvg(markup: string, size: number): string {
+    if (/<svg\b[^>]*\swidth=/i.test(markup)) {
+        return markup;
+    }
+    return markup.replace(/<svg\b/i, `<svg width="${size}" height="${size}"`);
+}
+
+export default SearchOverlay;

--- a/resources/js/hooks/useSearchOverlay.ts
+++ b/resources/js/hooks/useSearchOverlay.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseSearchOverlayReturn {
+    open: boolean;
+    openOverlay: () => void;
+    closeOverlay: () => void;
+    toggleOverlay: () => void;
+}
+
+/**
+ * Owns the global ⌘K / Ctrl+K listener that drives the SearchOverlay's
+ * open state.
+ *
+ * The listener treats ⌘K on macOS and Ctrl+K everywhere else as the
+ * canonical trigger and swallows the default browser shortcut (Chrome's
+ * omnibox search prefix, Firefox's search bar focus) so it can't fire
+ * underneath the overlay.
+ */
+export function useSearchOverlay(): UseSearchOverlayReturn {
+    const [open, setOpen] = useState(false);
+
+    const openOverlay = useCallback(() => setOpen(true), []);
+    const closeOverlay = useCallback(() => setOpen(false), []);
+    const toggleOverlay = useCallback(() => setOpen((current) => !current), []);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'k' && event.key !== 'K') {
+                return;
+            }
+            if (!(event.metaKey || event.ctrlKey) || event.altKey) {
+                return;
+            }
+            event.preventDefault();
+            setOpen((current) => !current);
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, []);
+
+    return { open, openOverlay, closeOverlay, toggleOverlay };
+}
+
+export default useSearchOverlay;

--- a/resources/js/layouts/DocsLayout.tsx
+++ b/resources/js/layouts/DocsLayout.tsx
@@ -2,16 +2,22 @@ import { Link } from '@inertiajs/react';
 import { ThemeToggle } from '@artisanpack-ui/react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
+import { SearchOverlay } from '../components/SearchOverlay';
 import { useMediaQuery } from '../hooks/useMediaQuery';
+import { useSearchOverlay } from '../hooks/useSearchOverlay';
 
 export interface DocsLayoutProps {
     children: ReactNode;
     sidebar?: ReactNode;
     toc?: ReactNode;
-    onSearchOpen?: () => void;
 }
 
-export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutProps) {
+export function DocsLayout({ children, sidebar, toc }: DocsLayoutProps) {
+    const {
+        open: searchOpen,
+        openOverlay: openSearch,
+        closeOverlay: closeSearch,
+    } = useSearchOverlay();
     const rootRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLElement>(null);
     const [mobileNavOpen, setMobileNavOpen] = useState(false);
@@ -67,14 +73,10 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
             ref={rootRef}
             className="min-h-screen bg-base text-text"
             style={{
-                background:
-                    'linear-gradient(180deg, var(--color-base) 0%, var(--ap-ink) 100%)',
+                background: 'linear-gradient(180deg, var(--color-base) 0%, var(--ap-ink) 100%)',
             }}
         >
-            <header
-                ref={headerRef}
-                className="sticky top-0 z-40 bg-base/90 backdrop-blur-[14px]"
-            >
+            <header ref={headerRef} className="sticky top-0 z-40 bg-base/90 backdrop-blur-[14px]">
                 <div className="flex h-[72px] w-full items-center gap-3 px-4 md:gap-7 md:px-7">
                     {sidebar ? (
                         <button
@@ -108,7 +110,7 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
 
                     <button
                         type="button"
-                        onClick={onSearchOpen}
+                        onClick={openSearch}
                         className="hidden h-[42px] flex-1 items-center gap-2.5 rounded-[10px] border border-border-subtle bg-surface-2 px-4 text-left text-small transition hover:border-border md:flex"
                         aria-label="Open search (⌘K)"
                     >
@@ -116,9 +118,7 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                             className="fa-solid fa-magnifying-glass text-[14px] text-text-subtle"
                             aria-hidden
                         />
-                        <span className="flex-1 text-text-subtle">
-                            Search the docs
-                        </span>
+                        <span className="flex-1 text-text-subtle">Search the docs</span>
                         <span className="ml-auto inline-flex gap-1">
                             <kbd className="rounded-[5px] border border-border-subtle bg-surface px-[7px] py-[2px] font-mono text-[11px] text-text-muted">
                                 ⌘
@@ -130,6 +130,14 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                     </button>
 
                     <div className="ml-auto flex items-center gap-1.5">
+                        <button
+                            type="button"
+                            onClick={openSearch}
+                            className="inline-flex h-[38px] w-[38px] items-center justify-center rounded-[9px] border border-border-subtle bg-surface-2 text-text-muted transition hover:text-text md:hidden"
+                            aria-label="Open search"
+                        >
+                            <i className="fa-solid fa-magnifying-glass text-[14px]" aria-hidden />
+                        </button>
                         <ThemeToggle />
                         <span
                             className="mx-1.5 hidden h-[22px] w-px bg-border-subtle md:block"
@@ -161,8 +169,7 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                     style={{
                         top: 'var(--docs-header-h, 76px)',
                         maxHeight: 'calc(100vh - var(--docs-header-h, 76px))',
-                        background:
-                            'linear-gradient(180deg, #080C16 0%, #05070E 100%)',
+                        background: 'linear-gradient(180deg, #080C16 0%, #05070E 100%)',
                     }}
                     aria-label="Documentation navigation"
                 >
@@ -173,9 +180,7 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                     {children}
 
                     {toc && !isDesktop ? (
-                        <div className="mt-12 border-t border-border-subtle pt-8">
-                            {toc}
-                        </div>
+                        <div className="mt-12 border-t border-border-subtle pt-8">{toc}</div>
                     ) : null}
                 </main>
 
@@ -204,8 +209,7 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                         id="docs-mobile-nav"
                         className={`absolute inset-y-0 left-0 flex w-[290px] max-w-[85vw] flex-col border-r border-border-subtle transition-transform duration-200 ${mobileNavOpen ? 'translate-x-0' : '-translate-x-full'}`}
                         style={{
-                            background:
-                                'linear-gradient(180deg, #080C16 0%, #05070E 100%)',
+                            background: 'linear-gradient(180deg, #080C16 0%, #05070E 100%)',
                         }}
                         aria-label="Documentation navigation"
                         // Removes the drawer's contents from tab
@@ -224,15 +228,10 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                                 className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[8px] border border-border-subtle bg-surface-2 text-text-muted transition hover:text-text"
                                 aria-label="Close navigation"
                             >
-                                <i
-                                    className="fa-solid fa-xmark text-[15px]"
-                                    aria-hidden
-                                />
+                                <i className="fa-solid fa-xmark text-[15px]" aria-hidden />
                             </button>
                         </div>
-                        <div className="flex-1 overflow-y-auto px-4 py-6">
-                            {sidebar}
-                        </div>
+                        <div className="flex-1 overflow-y-auto px-4 py-6">{sidebar}</div>
                     </aside>
                 </div>
             ) : null}
@@ -248,19 +247,13 @@ export function DocsLayout({ children, sidebar, toc, onSearchOpen }: DocsLayoutP
                     © ArtisanPack UI {new Date().getFullYear()}
                 </span>
             </footer>
+
+            {searchOpen ? <SearchOverlay onClose={closeSearch} /> : null}
         </div>
     );
 }
 
-function SocialIconLink({
-    href,
-    icon,
-    label,
-}: {
-    href: string;
-    icon: string;
-    label: string;
-}) {
+function SocialIconLink({ href, icon, label }: { href: string; icon: string; label: string }) {
     return (
         <a
             href={href}

--- a/tests/Feature/HeaderPartialTest.php
+++ b/tests/Feature/HeaderPartialTest.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
-it('marks the pending search block as aria-hidden until #88 lands the React SearchOverlay', function () {
+it('removes the placeholder search block now that #88 landed the React SearchOverlay', function () {
     $header = (string) file_get_contents(base_path('Modules/Core/resources/views/partials/header.blade.php'));
 
-    expect($header)->toContain('aria-hidden="true"');
+    expect($header)
+        ->not->toContain('x-artisanpack-input')
+        ->not->toContain('aria-hidden="true"')
+        ->not->toContain('readonly')
+        ->not->toContain('tabindex="-1"');
 });
 
 it('sets rel="noopener noreferrer" on every target="_blank" anchor in the header', function () {

--- a/tests/Feature/SearchControllerTest.php
+++ b/tests/Feature/SearchControllerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Packages\Changelog;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
+use Modules\Pages\Database\Factories\PageFactory;
+use Modules\Pages\Page;
+
+it('returns an empty result set for a blank query', function () {
+    $response = $this->getJson('/search');
+
+    $response
+        ->assertOk()
+        ->assertExactJson(['results' => []]);
+});
+
+it('trims whitespace-only queries down to empty', function () {
+    $response = $this->getJson('/search?q=%20%20');
+
+    $response
+        ->assertOk()
+        ->assertExactJson(['results' => []]);
+});
+
+it('matches pages by title and returns a stable link + page description', function () {
+    PageFactory::new()->create([
+        'title' => 'Getting Started Guide',
+        'slug' => 'getting-started',
+        'content' => 'Some body content.',
+        'parent' => 0,
+        'icon' => null,
+    ]);
+
+    $response = $this->getJson('/search?q=Getting');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results.0.name', 'Getting Started Guide')
+        ->assertJsonPath('results.0.description', 'Page')
+        ->assertJsonPath(
+            'results.0.link',
+            route('page.show', ['slug' => 'getting-started']),
+        );
+});
+
+it('labels child pages with the parent breadcrumb and links to page.child', function () {
+    /** @var Page $parent */
+    $parent = PageFactory::new()->create([
+        'title' => 'Guides',
+        'slug' => 'guides',
+        'parent' => 0,
+    ]);
+
+    PageFactory::new()->create([
+        'title' => 'Quickstart',
+        'slug' => 'quickstart',
+        'parent' => $parent->id,
+        'content' => 'body',
+    ]);
+
+    $response = $this->getJson('/search?q=Quickstart');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results.0.description', 'Page · Guides')
+        ->assertJsonPath(
+            'results.0.link',
+            route('page.child', ['parentSlug' => 'guides', 'slug' => 'quickstart']),
+        );
+});
+
+it('matches packages by name and points at the package homepage doc', function () {
+    $package = Package::factory()->create([
+        'name' => 'Nova Package',
+        'slug' => 'nova-package',
+        'homepage' => null,
+    ]);
+
+    $homeDoc = Documentation::create([
+        'title' => 'Home',
+        'slug' => 'home',
+        'content' => 'Landing',
+        'package_id' => $package->id,
+        'parent' => 0,
+        'menu_order' => 0,
+    ]);
+
+    $package->update(['homepage' => $homeDoc->id]);
+
+    $response = $this->getJson('/search?q=Nova');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results.0.name', 'Nova Package')
+        ->assertJsonPath('results.0.description', 'Package')
+        ->assertJsonPath(
+            'results.0.link',
+            route('documentation.show', ['package' => 'nova-package', 'slug' => 'home']),
+        );
+});
+
+it('falls back to the first doc when a matched package has no homepage set', function () {
+    $package = Package::factory()->create([
+        'name' => 'Orbit Package',
+        'slug' => 'orbit-package',
+        'homepage' => null,
+    ]);
+
+    Documentation::create([
+        'title' => 'Zeta',
+        'slug' => 'zeta',
+        'content' => '',
+        'package_id' => $package->id,
+        'parent' => 0,
+        'menu_order' => 5,
+    ]);
+
+    Documentation::create([
+        'title' => 'Alpha',
+        'slug' => 'alpha',
+        'content' => '',
+        'package_id' => $package->id,
+        'parent' => 0,
+        'menu_order' => 1,
+    ]);
+
+    $response = $this->getJson('/search?q=Orbit');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath(
+            'results.0.link',
+            route('documentation.show', ['package' => 'orbit-package', 'slug' => 'alpha']),
+        );
+});
+
+it('drops matched packages that have no publishable documentation', function () {
+    Package::factory()->create([
+        'name' => 'Empty Package',
+        'slug' => 'empty-package',
+        'homepage' => null,
+    ]);
+
+    $response = $this->getJson('/search?q=Empty');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results', []);
+});
+
+it('matches documentation and describes it as Documentation · Package', function () {
+    $package = Package::factory()->create([
+        'name' => 'Solar Package',
+        'slug' => 'solar-package',
+        'homepage' => null,
+    ]);
+
+    Documentation::create([
+        'title' => 'Deploying Solar',
+        'slug' => 'deploying-solar',
+        'content' => 'Body',
+        'package_id' => $package->id,
+        'parent' => 0,
+        'menu_order' => 0,
+    ]);
+
+    $response = $this->getJson('/search?q=Deploying');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results.0.name', 'Deploying Solar')
+        ->assertJsonPath('results.0.description', 'Documentation · Solar Package')
+        ->assertJsonPath(
+            'results.0.link',
+            route('documentation.show', ['package' => 'solar-package', 'slug' => 'deploying-solar']),
+        );
+});
+
+it('matches changelogs and links to the package changelog route', function () {
+    $package = Package::factory()->create([
+        'name' => 'Comet Package',
+        'slug' => 'comet-package',
+        'homepage' => null,
+    ]);
+
+    Changelog::create([
+        'title' => 'Comet Changelog',
+        'content' => 'Release notes',
+        'package_id' => $package->id,
+    ]);
+
+    $response = $this->getJson('/search?q=Comet%20Changelog');
+
+    $comet = collect($response->json('results'))
+        ->firstWhere('description', 'Changelog · Comet Package');
+
+    expect($comet)->not->toBeNull()
+        ->and($comet['name'])->toBe('Comet Changelog')
+        ->and($comet['link'])->toBe(route('changelog.show', ['package' => 'comet-package']));
+});
+
+it('resolves the icon into the shape the React overlay expects', function () {
+    PageFactory::new()->create([
+        'title' => 'Iconic',
+        'slug' => 'iconic',
+        'parent' => 0,
+        'icon' => 'fas.rocket',
+        'content' => '',
+    ]);
+
+    $response = $this->getJson('/search?q=Iconic');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('results.0.icon.type', 'class')
+        ->assertJsonPath('results.0.icon.class', 'fa-solid fa-rocket');
+});
+
+it('caps results per type at ten so a hot query cannot flood the overlay', function () {
+    for ($i = 0; $i < 15; $i++) {
+        PageFactory::new()->create([
+            'title' => "Flood Page {$i}",
+            'slug' => "flood-{$i}",
+            'parent' => 0,
+            'content' => '',
+        ]);
+    }
+
+    $response = $this->getJson('/search?q=Flood');
+
+    $response
+        ->assertOk()
+        ->assertJsonCount(10, 'results');
+});

--- a/tests/Feature/SearchOverlayTest.php
+++ b/tests/Feature/SearchOverlayTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+it('ships a SearchOverlay React component with the ⌘K plumbing', function () {
+    $overlay = (string) file_get_contents(base_path('resources/js/components/SearchOverlay.tsx'));
+
+    expect($overlay)
+        ->toContain('role="dialog"')
+        ->toContain('aria-modal="true"')
+        ->toContain('role="listbox"')
+        ->toContain('role="option"')
+        ->toContain('router.visit')
+        ->toContain("'ArrowDown'")
+        ->toContain("'ArrowUp'")
+        ->toContain("'Enter'")
+        ->toContain("'Escape'");
+});
+
+it('ships a useSearchOverlay hook that owns the ⌘K global listener', function () {
+    $hook = (string) file_get_contents(base_path('resources/js/hooks/useSearchOverlay.ts'));
+
+    expect($hook)
+        ->toContain("addEventListener('keydown'")
+        ->toContain('event.metaKey || event.ctrlKey')
+        ->toContain('preventDefault');
+});
+
+it('mounts the SearchOverlay inside DocsLayout and wires the header button to it', function () {
+    $layout = (string) file_get_contents(base_path('resources/js/layouts/DocsLayout.tsx'));
+
+    expect($layout)
+        ->toContain("from '../components/SearchOverlay'")
+        ->toContain("from '../hooks/useSearchOverlay'")
+        ->toContain('useSearchOverlay()')
+        ->toContain('<SearchOverlay')
+        ->toContain('onClick={openSearch}')
+        ->toContain('aria-label="Open search (⌘K)"');
+});
+
+it('registers the /search route pointing at SearchController@search', function () {
+    $routes = (string) file_get_contents(base_path('Modules/Core/routes/web.php'));
+
+    expect($routes)
+        ->toContain('SearchController')
+        ->toContain("Route::get('/search'")
+        ->toContain("->name('search')");
+});


### PR DESCRIPTION
## Summary

Ports the legacy `mary-search-open` spotlight to a React modal that opens on ⌘K / Ctrl+K from anywhere inside `DocsLayout`. Hits a new JSON `/search` endpoint that queries the same underlying data source (pages, packages, docs, changelogs) as the retired Livewire spotlight, but emits icons in the resolved-icon shape the rest of the Inertia UI already consumes.

## Related Issue

Closes #88

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

**Backend**

- `Modules/Core/Http/Controllers/SearchController` — JSON `GET /search?q=...` grouped by type (`Page · Parent`, `Package`, `Documentation · Pkg`, `Changelog · Pkg`), capped at 10 per type. Packages without publishable docs are dropped so a result row can never dead-end on a 404 or auth-guarded admin route.
- New public `Route::get('/search', …)` in `Modules/Core/routes/web.php`.

**Frontend**

- `resources/js/components/SearchOverlay.tsx` — modal palette: debounced fetch (250 ms), abort-on-retype, ↑/↓ to move highlight, Enter to `router.visit`, Escape / backdrop to close, body-scroll lock while open, and a guard against stale fetch responses that resolve after being superseded.
- `resources/js/hooks/useSearchOverlay.ts` — owns the global ⌘K / Ctrl+K listener (swallows the default browser shortcut so it can't fire underneath the overlay).
- `resources/js/layouts/DocsLayout.tsx` — mounts the overlay conditionally, wires the desktop header search button, adds a mobile magnifying-glass trigger, and drops the previously-dangling `onSearchOpen` prop from the public API.
- `Modules/Core/resources/views/partials/header.blade.php` — removes the `aria-hidden="true"` placeholder search block that had been reserved "until #88 lands".

## Breaking Changes

None. `DocsLayout`'s `onSearchOpen` prop is removed, but it wasn't being passed by any caller — the layout is now self-contained.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

New tests:

- `tests/Feature/SearchControllerTest.php` — 11 tests covering blank/whitespace queries, per-type matches, `Documentation · Package` labeling, homepage-doc link fallback, icon shape, 10-per-type cap, and filtered-out empty packages.
- `tests/Feature/SearchOverlayTest.php` — 4 snapshot tests locking in the ⌘K wiring across component + hook + layout + route.
- `tests/Feature/HeaderPartialTest.php` — updated to assert the placeholder is gone.

Full suite: **345 tests, 1,490 assertions, all passing**. Pint, ESLint, TypeScript, and `npm run build` all clean.

Manual verification checklist:

- Open a docs page (`/`, `/documentation/{pkg}/{slug}`, `/changelogs/{pkg}`, or a Page like `/about`).
- Press ⌘K (or click the header search button, or the mobile magnifying-glass) — overlay opens with focus in the input.
- Type — hits `/search?q=…` after ~250 ms and renders results grouped by type.
- ↑ / ↓ moves highlight, Enter navigates, Escape / backdrop closes.
- Body scroll is locked while the overlay is open.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

## Screenshots

<!-- Add screenshots of the overlay if desired -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global search overlay accessible from desktop and mobile search controls.
  - Open search with ⌘K on macOS or Ctrl+K on other platforms.
  - Search pages, packages, documentation, and changelogs with keyboard navigation and result links.
  - Added a backend search endpoint with normalized results, icons, and relevant documentation links.

- **Bug Fixes**
  - Removed the inactive search placeholder from the site header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->