### PR TITLE
feat: admin shell (/dashboard) with AdminLayout

### DIFF
--- a/Modules/Admin/routes/web.php
+++ b/Modules/Admin/routes/web.php
@@ -2,13 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Admin\Http\Controllers\AdminController;
-use Modules\Admin\Livewire\Dashboard;
 use Modules\Admin\Livewire\SettingsPage;
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('admins', AdminController::class)->names('admin');
-
-    Route::get('/dashboard', Dashboard::class)->name('dashboard');
 
     Route::get('/dashboard/settings', SettingsPage::class)->name('settings');
 });

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Dashboard/Index');
+    }
+}

--- a/resources/js/pages/Dashboard/Index.tsx
+++ b/resources/js/pages/Dashboard/Index.tsx
@@ -1,0 +1,28 @@
+import { Head } from '@inertiajs/react';
+import { Card } from '@artisanpack-ui/react/layout';
+
+import { AdminLayout } from '../../layouts/AdminLayout';
+
+export default function DashboardIndex() {
+    return (
+        <AdminLayout title="Dashboard">
+            <Head title="Dashboard" />
+
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+                <header>
+                    <p className="text-small text-text-muted">
+                        Manage packages, pages, and site settings from a single place.
+                    </p>
+                </header>
+
+                <Card>
+                    <h2 className="mb-2 font-display text-h6">Welcome back</h2>
+                    <p className="text-small text-text-muted">
+                        Use the sidebar to navigate the admin area. Package, documentation,
+                        and page management ship in upcoming releases.
+                    </p>
+                </Card>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Settings\AppearanceController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
@@ -8,6 +9,10 @@ use App\Http\Controllers\SitemapController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+});
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'dashboard/settings/profile');

--- a/tests/Feature/Admin/DashboardTest.php
+++ b/tests/Feature/Admin/DashboardTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Inertia\Testing\AssertableInertia;
 
 it('renders the admin dashboard for verified users', function (): void {
     $user = User::factory()->create([
@@ -11,5 +12,18 @@ it('renders the admin dashboard for verified users', function (): void {
 
     $this->actingAs($user)
         ->get('/dashboard')
-        ->assertOk();
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('Dashboard/Index'));
+});
+
+it('redirects guests to login', function (): void {
+    $this->get('/dashboard')->assertRedirect(route('login'));
+});
+
+it('redirects unverified users to email verification', function (): void {
+    $user = User::factory()->unverified()->create();
+
+    $this->actingAs($user)
+        ->get('/dashboard')
+        ->assertRedirect(route('verification.notice'));
 });


### PR DESCRIPTION
## Summary

Ports `/dashboard` from a Livewire component (`Modules\Admin\Livewire\Dashboard`) to an Inertia + React admin shell using the existing `AdminLayout` (sidebar nav, Fortify `auth` + `verified` guard). The landing view is a simple welcome card — package, page, and user management ship in the follow-up 3.0 issues (#27+).

## Related Issue

Closes #90

## Type of Change

- [x] New feature

## Changes

- Add `App\Http\Controllers\DashboardController` returning `Inertia::render('Dashboard/Index')`
- Add `resources/js/pages/Dashboard/Index.tsx` — welcome card inside `AdminLayout`
- Register `GET /dashboard` (name `dashboard`) in `routes/web.php` behind `auth` + `verified`
- Remove the orphaned Livewire route binding in `Modules/Admin/routes/web.php` (component class left in place for incremental Livewire teardown per plan §9.1 #3)
- Expand `tests/Feature/Admin/DashboardTest.php` with Inertia component assertion + guest / unverified redirect coverage

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

Verified with `php artisan test` (352 passed) and `npm run build`. Manually confirmed sidebar highlight, header, welcome card, and guest → login redirect.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass