### PR TITLE
feat: admin switcher between local and Google Analytics data sources

### DIFF
--- a/app/Analytics/AnalyticsSource.php
+++ b/app/Analytics/AnalyticsSource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Analytics;
+
+enum AnalyticsSource: string
+{
+    case Local = 'local';
+    case Google = 'google';
+
+    public const SETTING_KEY = 'analytics_dashboard_source';
+
+    public static function default(): self
+    {
+        return self::Local;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Local => 'Local (first-party)',
+            self::Google => 'Google Analytics',
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+}

--- a/app/Analytics/AnalyticsSourceResolver.php
+++ b/app/Analytics/AnalyticsSourceResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Analytics;
+
+use ArtisanPackUI\AnalyticsGoogle\Reporting\Ga4DataClient;
+use ArtisanPackUI\AnalyticsGoogle\Support\GoogleConnectionResolver;
+use ArtisanPackUI\Google\Models\GoogleConnection;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Modules\Core\Setting;
+
+class AnalyticsSourceResolver
+{
+    private ?AnalyticsSource $cachedSource = null;
+
+    public function __construct(
+        private readonly AuthFactory $auth,
+        private readonly GoogleConnectionResolver $connections,
+        private readonly Ga4DataClient $ga4Client,
+    ) {}
+
+    public function active(): AnalyticsSource
+    {
+        if ($this->cachedSource !== null) {
+            return $this->cachedSource;
+        }
+
+        $raw = Setting::query()->where('key', AnalyticsSource::SETTING_KEY)->value('value');
+        $source = is_string($raw) ? (AnalyticsSource::tryFrom($raw) ?? AnalyticsSource::default()) : AnalyticsSource::default();
+
+        return $this->cachedSource = $source;
+    }
+
+    public function set(AnalyticsSource $source): void
+    {
+        Setting::updateOrCreate(
+            ['key' => AnalyticsSource::SETTING_KEY],
+            ['value' => $source->value],
+        );
+
+        $this->cachedSource = $source;
+    }
+
+    public function googleConnection(): ?GoogleConnection
+    {
+        return $this->connections->forUser($this->auth->guard()->user());
+    }
+
+    public function isGoogleAvailable(): bool
+    {
+        return $this->ga4Client->isAvailable() && $this->googleConnection() !== null;
+    }
+}

--- a/app/Analytics/DashboardDataSourceManager.php
+++ b/app/Analytics/DashboardDataSourceManager.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Analytics;
+
+use ArtisanPackUI\Analytics\Analytics;
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Illuminate\Support\Collection;
+
+/**
+ * Container-bound replacement for the vendor AnalyticsQuery service.
+ *
+ * Extends the vendor class so InertiaDashboardController's typehint still
+ * resolves, then dispatches each dashboard-facing method to either the
+ * parent (local) implementation or a private google-scoped AnalyticsQuery
+ * built around Ga4QueryProvider.
+ *
+ * The `_source` filter injected into google-scoped calls differentiates
+ * cache keys so a source switch never surfaces stale rows from the other
+ * provider.
+ */
+class DashboardDataSourceManager extends AnalyticsQuery
+{
+    private readonly AnalyticsQuery $googleQuery;
+
+    public function __construct(
+        Analytics $localProvider,
+        private readonly Ga4QueryProvider $googleProvider,
+        private readonly AnalyticsSourceResolver $resolver,
+    ) {
+        parent::__construct($localProvider);
+        $this->googleQuery = new AnalyticsQuery($this->googleProvider);
+    }
+
+    public function getStats(DateRange $range, bool $withCompare = true, array $filters = []): array
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getStats($range, $withCompare, $this->tagFilters($filters));
+        }
+
+        return parent::getStats($range, $withCompare, $filters);
+    }
+
+    public function getPageViews(DateRange $range, string $granularity = 'day', array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getPageViews($range, $granularity, $this->tagFilters($filters));
+        }
+
+        return parent::getPageViews($range, $granularity, $filters);
+    }
+
+    public function getTopPages(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getTopPages($range, $limit, $this->tagFilters($filters));
+        }
+
+        return parent::getTopPages($range, $limit, $filters);
+    }
+
+    public function getTrafficSources(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getTrafficSources($range, $limit, $this->tagFilters($filters));
+        }
+
+        return parent::getTrafficSources($range, $limit, $filters);
+    }
+
+    public function getDeviceBreakdown(DateRange $range, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getDeviceBreakdown($range, $this->tagFilters($filters));
+        }
+
+        return parent::getDeviceBreakdown($range, $filters);
+    }
+
+    public function getBrowserBreakdown(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getBrowserBreakdown($range, $limit, $this->tagFilters($filters));
+        }
+
+        return parent::getBrowserBreakdown($range, $limit, $filters);
+    }
+
+    public function getCountryBreakdown(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getCountryBreakdown($range, $limit, $this->tagFilters($filters));
+        }
+
+        return parent::getCountryBreakdown($range, $limit, $filters);
+    }
+
+    public function getEventBreakdown(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        if ($this->useGoogle()) {
+            return $this->googleProvider->eventBreakdown($range, $limit);
+        }
+
+        return parent::getEventBreakdown($range, $limit, $filters);
+    }
+
+    public function getRealtime(int $minutes = 5, array $filters = []): array
+    {
+        if ($this->useGoogle()) {
+            return $this->googleQuery->getRealtime($minutes, $this->tagFilters($filters));
+        }
+
+        return parent::getRealtime($minutes, $filters);
+    }
+
+    public function activeSource(): AnalyticsSource
+    {
+        return $this->useGoogle() ? AnalyticsSource::Google : AnalyticsSource::Local;
+    }
+
+    private function useGoogle(): bool
+    {
+        return $this->resolver->active() === AnalyticsSource::Google
+            && $this->resolver->isGoogleAvailable();
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return array<string, mixed>
+     */
+    private function tagFilters(array $filters): array
+    {
+        $filters['_source'] = AnalyticsSource::Google->value;
+
+        return $filters;
+    }
+}

--- a/app/Analytics/Ga4QueryProvider.php
+++ b/app/Analytics/Ga4QueryProvider.php
@@ -1,0 +1,462 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Analytics;
+
+use ArtisanPackUI\Analytics\Contracts\AnalyticsQueryInterface;
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\DateRange as GaDateRange;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\Ga4DataClient;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\ReportRequest;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\ReportResponse;
+use ArtisanPackUI\Google\Exceptions\TokenRefreshException;
+use ArtisanPackUI\Google\Tokens\TokenManager;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class Ga4QueryProvider implements AnalyticsQueryInterface
+{
+    private const M_PAGE_VIEWS = 'screenPageViews';
+
+    private const M_USERS = 'totalUsers';
+
+    private const M_SESSIONS = 'sessions';
+
+    private const M_BOUNCE = 'bounceRate';
+
+    private const M_AVG_DURATION = 'averageSessionDuration';
+
+    private const M_EVENT_COUNT = 'eventCount';
+
+    private const D_PAGE_PATH = 'pagePath';
+
+    private const D_PAGE_TITLE = 'pageTitle';
+
+    private const D_SOURCE = 'sessionSource';
+
+    private const D_MEDIUM = 'sessionMedium';
+
+    private const D_DEVICE = 'deviceCategory';
+
+    private const D_BROWSER = 'browser';
+
+    private const D_BROWSER_VERSION = 'browserVersion';
+
+    private const D_COUNTRY = 'country';
+
+    private const D_COUNTRY_ID = 'countryId';
+
+    private const D_DATE = 'date';
+
+    private const D_DATE_HOUR = 'dateHour';
+
+    private const D_YEAR_WEEK = 'yearWeek';
+
+    private const D_YEAR_MONTH = 'yearMonth';
+
+    private const D_EVENT_NAME = 'eventName';
+
+    public function __construct(
+        private readonly Ga4DataClient $client,
+        private readonly AnalyticsSourceResolver $resolver,
+        private readonly ConfigRepository $config,
+        private readonly HttpFactory $http,
+        private readonly ?TokenManager $tokens = null,
+        private readonly ?CacheRepository $cache = null,
+    ) {}
+
+    public function getPageViews(DateRange $range, array $filters = []): int
+    {
+        return (int) $this->totalMetric($range, self::M_PAGE_VIEWS);
+    }
+
+    public function getVisitors(DateRange $range, array $filters = []): int
+    {
+        return (int) $this->totalMetric($range, self::M_USERS);
+    }
+
+    public function getSessions(DateRange $range, array $filters = []): int
+    {
+        return (int) $this->totalMetric($range, self::M_SESSIONS);
+    }
+
+    public function getBounceRate(DateRange $range, array $filters = []): float
+    {
+        return round($this->totalMetric($range, self::M_BOUNCE) * 100, 2);
+    }
+
+    public function getAverageSessionDuration(DateRange $range, array $filters = []): int
+    {
+        return (int) round($this->totalMetric($range, self::M_AVG_DURATION));
+    }
+
+    public function getTopPages(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_PAGE_VIEWS, self::M_USERS],
+            [self::D_PAGE_PATH, self::D_PAGE_TITLE],
+            [['metric' => self::M_PAGE_VIEWS, 'desc' => true]],
+            $this->clampLimit($limit),
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        return collect($response->rows())->map(fn (array $row): array => [
+            'path' => (string) ($row[self::D_PAGE_PATH] ?? ''),
+            'title' => (string) ($row[self::D_PAGE_TITLE] ?? ''),
+            'views' => (int) ($row[self::M_PAGE_VIEWS] ?? 0),
+            'unique_views' => (int) ($row[self::M_USERS] ?? 0),
+        ])->values();
+    }
+
+    public function getTrafficSources(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_SESSIONS, self::M_USERS],
+            [self::D_SOURCE, self::D_MEDIUM],
+            [['metric' => self::M_SESSIONS, 'desc' => true]],
+            $this->clampLimit($limit),
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        return collect($response->rows())->map(fn (array $row): array => [
+            'source' => (string) ($row[self::D_SOURCE] ?? ''),
+            'medium' => (string) ($row[self::D_MEDIUM] ?? ''),
+            'sessions' => (int) ($row[self::M_SESSIONS] ?? 0),
+            'visitors' => (int) ($row[self::M_USERS] ?? 0),
+        ])->values();
+    }
+
+    public function getPageViewsOverTime(DateRange $range, string $granularity = 'day', array $filters = []): Collection
+    {
+        [$dateDimension, $dateFormatter] = $this->granularityConfig($granularity);
+
+        $response = $this->runReport(
+            $range,
+            [self::M_PAGE_VIEWS, self::M_USERS],
+            [$dateDimension],
+            [['dimension' => $dateDimension, 'desc' => false]],
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        return collect($response->rows())->map(fn (array $row): array => [
+            'date' => $dateFormatter((string) ($row[$dateDimension] ?? '')),
+            'pageviews' => (int) ($row[self::M_PAGE_VIEWS] ?? 0),
+            'visitors' => (int) ($row[self::M_USERS] ?? 0),
+        ])->values();
+    }
+
+    public function getDeviceBreakdown(DateRange $range, array $filters = []): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_SESSIONS],
+            [self::D_DEVICE],
+            [['metric' => self::M_SESSIONS, 'desc' => true]],
+        );
+
+        return $this->breakdownWithPercentage($response, self::D_DEVICE, self::M_SESSIONS, 'device_type');
+    }
+
+    public function getBrowserBreakdown(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_SESSIONS],
+            [self::D_BROWSER, self::D_BROWSER_VERSION],
+            [['metric' => self::M_SESSIONS, 'desc' => true]],
+            $this->clampLimit($limit),
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        $rows = $response->rows();
+        $total = array_sum(array_map(fn (array $row): int => (int) ($row[self::M_SESSIONS] ?? 0), $rows));
+
+        return collect($rows)->map(fn (array $row): array => [
+            'browser' => (string) ($row[self::D_BROWSER] ?? ''),
+            'version' => (string) ($row[self::D_BROWSER_VERSION] ?? ''),
+            'sessions' => (int) ($row[self::M_SESSIONS] ?? 0),
+            'percentage' => $total > 0
+                ? round(((int) ($row[self::M_SESSIONS] ?? 0) / $total) * 100, 2)
+                : 0.0,
+        ])->values();
+    }
+
+    public function getCountryBreakdown(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_SESSIONS],
+            [self::D_COUNTRY, self::D_COUNTRY_ID],
+            [['metric' => self::M_SESSIONS, 'desc' => true]],
+            $this->clampLimit($limit),
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        $rows = $response->rows();
+        $total = array_sum(array_map(fn (array $row): int => (int) ($row[self::M_SESSIONS] ?? 0), $rows));
+
+        return collect($rows)->map(fn (array $row): array => [
+            'country' => (string) ($row[self::D_COUNTRY] ?? ''),
+            'country_code' => (string) ($row[self::D_COUNTRY_ID] ?? ''),
+            'sessions' => (int) ($row[self::M_SESSIONS] ?? 0),
+            'percentage' => $total > 0
+                ? round(((int) ($row[self::M_SESSIONS] ?? 0) / $total) * 100, 2)
+                : 0.0,
+        ])->values();
+    }
+
+    public function getRealTimeVisitors(int $minutes = 5, array $filters = []): int
+    {
+        $connection = $this->resolver->googleConnection();
+
+        if ($connection === null || $this->tokens === null) {
+            return 0;
+        }
+
+        $property = $this->propertyId();
+
+        if ($property === null) {
+            return 0;
+        }
+
+        try {
+            $accessToken = $this->tokens->getValidAccessToken($connection);
+        } catch (TokenRefreshException) {
+            return 0;
+        }
+
+        $minutesAgo = max(1, min(30, $minutes));
+        $endpoint = sprintf(
+            '%s/properties/%s:runRealtimeReport',
+            rtrim((string) $this->config->get('analytics-google.reporting.api_base', 'https://analyticsdata.googleapis.com/v1beta'), '/'),
+            rawurlencode($property),
+        );
+
+        $payload = [
+            'metrics' => [['name' => 'activeUsers']],
+            'minuteRanges' => [[
+                'startMinutesAgo' => $minutesAgo,
+                'endMinutesAgo' => 0,
+            ]],
+        ];
+
+        try {
+            $response = $this->http
+                ->timeout((int) $this->config->get('analytics-google.reporting.timeout', 30))
+                ->withToken($accessToken)
+                ->acceptJson()
+                ->asJson()
+                ->post($endpoint, $payload);
+        } catch (ConnectionException) {
+            return 0;
+        }
+
+        if (! $response->successful()) {
+            return 0;
+        }
+
+        $body = $response->json();
+        $rows = is_array($body) && isset($body['rows']) && is_array($body['rows']) ? $body['rows'] : [];
+        $total = 0;
+
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $values = is_array($row['metricValues'] ?? null) ? $row['metricValues'] : [];
+            $value = $values[0]['value'] ?? '0';
+
+            if (is_numeric($value)) {
+                $total += (int) $value;
+            }
+        }
+
+        return $total;
+    }
+
+    public function getTopBotAgents(DateRange $range, int $limit = 10, array $filters = []): Collection
+    {
+        return collect();
+    }
+
+    /**
+     * Event breakdown by eventName. Not on the interface — called directly by
+     * DashboardDataSourceManager::getEventBreakdown when Google is active.
+     *
+     * @return Collection<int, array{name: string, category: string, count: int, total_value: float, percentage: float}>
+     */
+    public function eventBreakdown(DateRange $range, int $limit = 10): Collection
+    {
+        $response = $this->runReport(
+            $range,
+            [self::M_EVENT_COUNT],
+            [self::D_EVENT_NAME],
+            [['metric' => self::M_EVENT_COUNT, 'desc' => true]],
+            $this->clampLimit($limit),
+        );
+
+        if ($response === null) {
+            return collect();
+        }
+
+        $rows = $response->rows();
+        $total = array_sum(array_map(fn (array $row): int => (int) ($row[self::M_EVENT_COUNT] ?? 0), $rows));
+
+        return collect($rows)->map(fn (array $row): array => [
+            'name' => (string) ($row[self::D_EVENT_NAME] ?? ''),
+            'category' => '',
+            'count' => (int) ($row[self::M_EVENT_COUNT] ?? 0),
+            'total_value' => 0.0,
+            'percentage' => $total > 0
+                ? round(((int) ($row[self::M_EVENT_COUNT] ?? 0) / $total) * 100, 2)
+                : 0.0,
+        ])->values();
+    }
+
+    private function totalMetric(DateRange $range, string $metric): float
+    {
+        $response = $this->runReport($range, [$metric]);
+
+        return $response === null ? 0.0 : $response->totalFor($metric);
+    }
+
+    /**
+     * @param  list<string>  $metrics
+     * @param  list<string>  $dimensions
+     * @param  list<array{metric?: string, dimension?: string, desc?: bool}>  $orderBys
+     */
+    private function runReport(
+        DateRange $range,
+        array $metrics,
+        array $dimensions = [],
+        array $orderBys = [],
+        ?int $limit = null,
+    ): ?ReportResponse {
+        $connection = $this->resolver->googleConnection();
+
+        if ($connection === null || ! $this->client->isAvailable()) {
+            return null;
+        }
+
+        try {
+            return $this->client->runReport(
+                ReportRequest::make(
+                    range: $this->convertRange($range),
+                    metrics: $metrics,
+                    dimensions: $dimensions,
+                    orderBys: $orderBys,
+                    limit: $limit,
+                ),
+                $connection,
+            );
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function convertRange(DateRange $range): GaDateRange
+    {
+        return new GaDateRange(
+            $range->startDate->format('Y-m-d'),
+            $range->endDate->format('Y-m-d'),
+        );
+    }
+
+    /**
+     * @return array{0: string, 1: callable(string): string}
+     */
+    private function granularityConfig(string $granularity): array
+    {
+        return match ($granularity) {
+            'hour' => [self::D_DATE_HOUR, static function (string $raw): string {
+                if (strlen($raw) === 10 && ctype_digit($raw)) {
+                    return sprintf(
+                        '%s-%s-%s %s:00:00',
+                        substr($raw, 0, 4),
+                        substr($raw, 4, 2),
+                        substr($raw, 6, 2),
+                        substr($raw, 8, 2),
+                    );
+                }
+
+                return $raw;
+            }],
+            'week' => [self::D_YEAR_WEEK, static fn (string $raw): string => $raw],
+            'month' => [self::D_YEAR_MONTH, static function (string $raw): string {
+                if (strlen($raw) === 6 && ctype_digit($raw)) {
+                    return sprintf('%s-%s', substr($raw, 0, 4), substr($raw, 4, 2));
+                }
+
+                return $raw;
+            }],
+            default => [self::D_DATE, static function (string $raw): string {
+                if (strlen($raw) === 8 && ctype_digit($raw)) {
+                    return sprintf(
+                        '%s-%s-%s',
+                        substr($raw, 0, 4),
+                        substr($raw, 4, 2),
+                        substr($raw, 6, 2),
+                    );
+                }
+
+                return $raw;
+            }],
+        };
+    }
+
+    /**
+     * @return Collection<int, array{device_type: string, sessions: int, percentage: float}>
+     */
+    private function breakdownWithPercentage(?ReportResponse $response, string $dimension, string $metric, string $labelKey): Collection
+    {
+        if ($response === null) {
+            return collect();
+        }
+
+        $rows = $response->rows();
+        $total = array_sum(array_map(fn (array $row): int => (int) ($row[$metric] ?? 0), $rows));
+
+        return collect($rows)->map(fn (array $row): array => [
+            $labelKey => (string) ($row[$dimension] ?? ''),
+            'sessions' => (int) ($row[$metric] ?? 0),
+            'percentage' => $total > 0
+                ? round(((int) ($row[$metric] ?? 0) / $total) * 100, 2)
+                : 0.0,
+        ])->values();
+    }
+
+    private function propertyId(): ?string
+    {
+        $id = (string) ($this->config->get('analytics-google.reporting.property_id') ?? '');
+
+        return $id === '' ? null : $id;
+    }
+
+    private function clampLimit(int $limit): int
+    {
+        return max(1, min(100, $limit));
+    }
+}

--- a/app/Http/Controllers/Analytics/SourceController.php
+++ b/app/Http/Controllers/Analytics/SourceController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Analytics;
+
+use App\Analytics\AnalyticsSource;
+use App\Analytics\AnalyticsSourceResolver;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class SourceController extends Controller
+{
+    public function update(Request $request, AnalyticsSourceResolver $resolver): RedirectResponse
+    {
+        $validated = $request->validate([
+            'source' => ['required', Rule::in(array_keys(AnalyticsSource::options()))],
+        ]);
+
+        $source = AnalyticsSource::from($validated['source']);
+
+        if ($source === AnalyticsSource::Google && ! $resolver->isGoogleAvailable()) {
+            return back()->with(
+                'error',
+                'Connect a Google account at Integrations → Google before selecting Google Analytics as the source.',
+            );
+        }
+
+        $resolver->set($source);
+
+        return back()->with('success', 'Analytics source updated to '.$source->label().'.');
+    }
+}

--- a/app/Http/HandleInertiaRequests.php
+++ b/app/Http/HandleInertiaRequests.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http;
 
+use App\Analytics\AnalyticsSource;
+use App\Analytics\AnalyticsSourceResolver;
+use App\Models\User;
 use App\Services\InertiaSeo;
 use ArtisanPackUI\Privacy\Services\ReconsentService;
 use Illuminate\Http\Request;
@@ -42,6 +45,31 @@ class HandleInertiaRequests extends Middleware
                 description: config('seo.site.description') ?: null,
             ),
             'reconsent' => fn () => $this->reconsentPolicy($request),
+            'analyticsSource' => fn () => $this->analyticsSourceProps($request),
+        ];
+    }
+
+    /**
+     * Shape used by the analytics sub-nav's source switcher. Only populated
+     * for admins so a non-admin can neither see nor toggle the setting.
+     *
+     * @return array{active: string, options: array<string, string>, google_available: bool, update_url: string}|null
+     */
+    protected function analyticsSourceProps(Request $request): ?array
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User || ! $user->isAdmin()) {
+            return null;
+        }
+
+        $resolver = app(AnalyticsSourceResolver::class);
+
+        return [
+            'active' => $resolver->active()->value,
+            'options' => AnalyticsSource::options(),
+            'google_available' => $resolver->isGoogleAvailable(),
+            'update_url' => route('dashboard.analytics.source.update'),
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Analytics\DashboardDataSourceManager;
 use App\Http\Middleware\CoerceAnalyticsBeaconTypes;
 use App\Models\User;
+use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
@@ -22,7 +24,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Swap the vendor AnalyticsQuery service for our source-switching
+        // subclass so the vendor InertiaDashboardController transparently
+        // dispatches to either the local provider or GA4 based on the
+        // active `analytics_dashboard_source` setting.
+        $this->app->bind(AnalyticsQuery::class, DashboardDataSourceManager::class);
     }
 
     /**

--- a/resources/js/pages/Analytics/components/AnalyticsSubNav.tsx
+++ b/resources/js/pages/Analytics/components/AnalyticsSubNav.tsx
@@ -1,4 +1,6 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link, router, usePage } from '@inertiajs/react';
+
+import type { SharedProps } from '../../../types/inertia';
 
 interface AnalyticsSubNavItem {
     label: string;
@@ -15,8 +17,9 @@ const ITEMS: AnalyticsSubNavItem[] = [
 ];
 
 export function AnalyticsSubNav() {
-    const { url } = usePage();
-    const currentPath = url.split( '?' )[ 0 ];
+    const page = usePage<SharedProps>();
+    const currentPath = page.url.split( '?' )[ 0 ];
+    const analytics = page.props.analyticsSource;
 
     // Longest-prefix match so a nested route (e.g. .../pages) doesn't
     // also highlight the shorter Overview link (which matches every
@@ -25,42 +28,91 @@ export function AnalyticsSubNav() {
         .sort( ( a, b ) => b.href.length - a.href.length )
         .find( ( item ) => currentPath === item.href );
 
+    const handleSourceChange = ( event: React.ChangeEvent<HTMLSelectElement> ): void => {
+        if ( ! analytics ) {
+            return;
+        }
+
+        router.post(
+            analytics.update_url,
+            { source: event.target.value },
+            { preserveScroll: true },
+        );
+    };
+
     return (
-        <nav
-            aria-label="Analytics sections"
-            className="relative border-b border-transparent"
-            style={{
-                // Gradient hairline directly under the tab row, using
-                // the same `--grad-neon` token that powers the Docs
-                // layout header underline. Rendered as a background
-                // image on a 1px-tall pseudo-track so it stays crisp
-                // at every DPR without needing a real border.
-                backgroundImage:
-                    'linear-gradient(to right, var(--color-border-subtle), var(--color-border-subtle)), var(--grad-neon)',
-                backgroundSize: '100% 1px, 100% 1px',
-                backgroundPosition: 'bottom left, bottom left',
-                backgroundRepeat: 'no-repeat, no-repeat',
-            }}
-        >
-            <ul className="flex flex-wrap gap-6 px-1 pb-3">
-                {ITEMS.map( ( item ) => {
-                    const isActive = active?.href === item.href;
-                    return (
-                        <li key={item.href}>
-                            <Link
-                                href={item.href}
-                                className={`inline-flex items-center border-b-2 pb-1 text-small font-medium transition ${
-                                    isActive
-                                        ? 'border-secondary text-text'
-                                        : 'border-transparent text-text-muted hover:border-border hover:text-text'
-                                }`}
+        <div className="flex flex-col gap-2">
+            <nav
+                aria-label="Analytics sections"
+                className="relative border-b border-transparent"
+                style={{
+                    // Gradient hairline directly under the tab row, using
+                    // the same `--grad-neon` token that powers the Docs
+                    // layout header underline. Rendered as a background
+                    // image on a 1px-tall pseudo-track so it stays crisp
+                    // at every DPR without needing a real border.
+                    backgroundImage:
+                        'linear-gradient(to right, var(--color-border-subtle), var(--color-border-subtle)), var(--grad-neon)',
+                    backgroundSize: '100% 1px, 100% 1px',
+                    backgroundPosition: 'bottom left, bottom left',
+                    backgroundRepeat: 'no-repeat, no-repeat',
+                }}
+            >
+                <div className="flex flex-wrap items-end justify-between gap-4 px-1 pb-3">
+                    <ul className="flex flex-wrap gap-6">
+                        {ITEMS.map( ( item ) => {
+                            const isActive = active?.href === item.href;
+                            return (
+                                <li key={item.href}>
+                                    <Link
+                                        href={item.href}
+                                        className={`inline-flex items-center border-b-2 pb-1 text-small font-medium transition ${
+                                            isActive
+                                                ? 'border-secondary text-text'
+                                                : 'border-transparent text-text-muted hover:border-border hover:text-text'
+                                        }`}
+                                    >
+                                        {item.label}
+                                    </Link>
+                                </li>
+                            );
+                        } )}
+                    </ul>
+                    {analytics ? (
+                        <label className="flex items-center gap-2 text-small text-text-muted">
+                            <span>Source</span>
+                            <select
+                                value={analytics.active}
+                                onChange={handleSourceChange}
+                                className="rounded-[8px] border border-border-subtle bg-surface px-3 py-1.5 text-small text-text focus:border-secondary focus:outline-none"
                             >
-                                {item.label}
-                            </Link>
-                        </li>
-                    );
-                } )}
-            </ul>
-        </nav>
+                                {Object.entries( analytics.options ).map( ( [ id, label ] ) => (
+                                    <option
+                                        key={id}
+                                        value={id}
+                                        disabled={id === 'google' && ! analytics.google_available}
+                                    >
+                                        {label}
+                                        {id === 'google' && ! analytics.google_available
+                                            ? ' (connect account)'
+                                            : ''}
+                                    </option>
+                                ) )}
+                            </select>
+                        </label>
+                    ) : null}
+                </div>
+            </nav>
+            {analytics && analytics.active === 'google' && ! analytics.google_available ? (
+                <p className="px-1 text-xsmall text-text-subtle">
+                    Google is selected but no connected Google account is available. Connect
+                    one at{ ' ' }
+                    <Link href="/dashboard/integrations/google" className="underline">
+                        Integrations → Google
+                    </Link>
+                    { ' ' }or switch back to Local.
+                </p>
+            ) : null}
+        </div>
     );
 }

--- a/resources/js/types/inertia.d.ts
+++ b/resources/js/types/inertia.d.ts
@@ -40,12 +40,20 @@ export interface ReconsentPolicy {
     url: string;
 }
 
+export interface AnalyticsSourceShared {
+    active: string;
+    options: Record<string, string>;
+    google_available: boolean;
+    update_url: string;
+}
+
 export interface SharedProps {
     [key: string]: unknown;
     flash: FlashData;
     auth: { user: AuthUser | null };
     seo: SeoData;
     reconsent: ReconsentPolicy | null;
+    analyticsSource: AnalyticsSourceShared | null;
 }
 
 export type PageProps<T extends object = object> = T & SharedProps;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Analytics\RealtimeController as AnalyticsRealtimeController;
+use App\Http\Controllers\Analytics\SourceController as AnalyticsSourceController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Integrations\GoogleController as GoogleIntegrationController;
 use App\Http\Controllers\Settings\AppearanceController;
@@ -40,6 +41,11 @@ Route::middleware(['auth', 'verified', 'can:view-analytics'])->group(function ()
     // 10-second refresh.
     Route::get('dashboard/analytics/realtime/feed', [AnalyticsRealtimeController::class, 'feed'])
         ->name('dashboard.analytics.realtime.feed');
+
+    // Persists the admin's choice between the local first-party analytics
+    // store and Google Analytics for every /dashboard/analytics/* page.
+    Route::post('dashboard/analytics/source', [AnalyticsSourceController::class, 'update'])
+        ->name('dashboard.analytics.source.update');
 });
 
 Route::middleware(['auth'])->group(function () {

--- a/tests/Feature/Analytics/Ga4QueryProviderTest.php
+++ b/tests/Feature/Analytics/Ga4QueryProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Analytics\AnalyticsSourceResolver;
+use App\Analytics\Ga4QueryProvider;
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\Ga4DataClient;
+use ArtisanPackUI\AnalyticsGoogle\Reporting\ReportResponse;
+use ArtisanPackUI\Google\Models\GoogleConnection;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Support\Carbon;
+
+function ga4Provider(?ReportResponse $response, bool $connected = true): Ga4QueryProvider
+{
+    $client = Mockery::mock(Ga4DataClient::class);
+    $client->shouldReceive('isAvailable')->andReturn(true);
+
+    if ($response !== null) {
+        $client->shouldReceive('runReport')->andReturn($response);
+    }
+
+    $resolver = Mockery::mock(AnalyticsSourceResolver::class);
+    $resolver->shouldReceive('googleConnection')->andReturn(
+        $connected ? new GoogleConnection : null,
+    );
+
+    return new Ga4QueryProvider(
+        $client,
+        $resolver,
+        app('config'),
+        app(HttpFactory::class),
+    );
+}
+
+function ga4Range(): DateRange
+{
+    return new DateRange(
+        Carbon::parse('2026-06-01'),
+        Carbon::parse('2026-06-30'),
+    );
+}
+
+it('returns zero for total metrics when no google connection is available', function () {
+    $provider = ga4Provider(response: null, connected: false);
+
+    expect($provider->getPageViews(ga4Range()))->toBe(0)
+        ->and($provider->getVisitors(ga4Range()))->toBe(0)
+        ->and($provider->getSessions(ga4Range()))->toBe(0);
+});
+
+it('sums total metrics across every returned row', function () {
+    $response = new ReportResponse([
+        'metricHeaders' => [['name' => 'screenPageViews']],
+        'rows' => [
+            ['metricValues' => [['value' => '120']]],
+            ['metricValues' => [['value' => '80']]],
+        ],
+    ]);
+
+    expect(ga4Provider($response)->getPageViews(ga4Range()))->toBe(200);
+});
+
+it('parses top pages into the local shape', function () {
+    $response = new ReportResponse([
+        'dimensionHeaders' => [['name' => 'pagePath'], ['name' => 'pageTitle']],
+        'metricHeaders' => [['name' => 'screenPageViews'], ['name' => 'totalUsers']],
+        'rows' => [
+            [
+                'dimensionValues' => [['value' => '/docs/getting-started'], ['value' => 'Getting Started']],
+                'metricValues' => [['value' => '340'], ['value' => '210']],
+            ],
+            [
+                'dimensionValues' => [['value' => '/pricing'], ['value' => 'Pricing']],
+                'metricValues' => [['value' => '120'], ['value' => '95']],
+            ],
+        ],
+    ]);
+
+    $rows = ga4Provider($response)->getTopPages(ga4Range())->all();
+
+    expect($rows)->toHaveCount(2)
+        ->and($rows[0])->toMatchArray([
+            'path' => '/docs/getting-started',
+            'title' => 'Getting Started',
+            'views' => 340,
+            'unique_views' => 210,
+        ]);
+});
+
+it('normalises GA4 YYYYMMDD dates on the daily time series', function () {
+    $response = new ReportResponse([
+        'dimensionHeaders' => [['name' => 'date']],
+        'metricHeaders' => [['name' => 'screenPageViews'], ['name' => 'totalUsers']],
+        'rows' => [
+            [
+                'dimensionValues' => [['value' => '20260601']],
+                'metricValues' => [['value' => '10'], ['value' => '7']],
+            ],
+        ],
+    ]);
+
+    $rows = ga4Provider($response)->getPageViewsOverTime(ga4Range())->all();
+
+    expect($rows[0]['date'])->toBe('2026-06-01');
+});
+
+it('computes percentage shares on the browser breakdown', function () {
+    $response = new ReportResponse([
+        'dimensionHeaders' => [['name' => 'browser'], ['name' => 'browserVersion']],
+        'metricHeaders' => [['name' => 'sessions']],
+        'rows' => [
+            [
+                'dimensionValues' => [['value' => 'Chrome'], ['value' => '128']],
+                'metricValues' => [['value' => '75']],
+            ],
+            [
+                'dimensionValues' => [['value' => 'Safari'], ['value' => '17']],
+                'metricValues' => [['value' => '25']],
+            ],
+        ],
+    ]);
+
+    $rows = ga4Provider($response)->getBrowserBreakdown(ga4Range())->all();
+
+    expect($rows[0]['percentage'])->toBe(75.0)
+        ->and($rows[1]['percentage'])->toBe(25.0);
+});

--- a/tests/Feature/Analytics/SourceControllerTest.php
+++ b/tests/Feature/Analytics/SourceControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Analytics\AnalyticsSource;
+use App\Analytics\AnalyticsSourceResolver;
+use App\Enums\Role;
+use App\Models\User;
+use Modules\Core\Setting;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+it('requires authentication', function () {
+    post(route('dashboard.analytics.source.update'), ['source' => 'local'])
+        ->assertRedirect(route('login'));
+});
+
+it('rejects non-admin users via the view-analytics gate', function () {
+    $editor = User::factory()->create([
+        'role' => Role::Editor,
+        'email_verified_at' => now(),
+    ]);
+
+    actingAs($editor)
+        ->post(route('dashboard.analytics.source.update'), ['source' => 'local'])
+        ->assertForbidden();
+});
+
+it('rejects an unknown source value', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    actingAs($admin)
+        ->post(route('dashboard.analytics.source.update'), ['source' => 'segment'])
+        ->assertSessionHasErrors('source');
+});
+
+it('persists the local source to Setting', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    actingAs($admin)
+        ->post(route('dashboard.analytics.source.update'), ['source' => 'local'])
+        ->assertSessionHas('success');
+
+    expect(Setting::query()->where('key', AnalyticsSource::SETTING_KEY)->value('value'))
+        ->toBe('local');
+});
+
+it('refuses google when no google connection is available', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    // Force the resolver to report Google as unavailable regardless of the
+    // (empty) test DB state so the assertion is deterministic.
+    $this->mock(AnalyticsSourceResolver::class, function ($mock) {
+        $mock->shouldReceive('isGoogleAvailable')->andReturn(false);
+        $mock->shouldNotReceive('set');
+    });
+
+    actingAs($admin)
+        ->post(route('dashboard.analytics.source.update'), ['source' => 'google'])
+        ->assertSessionHas('error');
+
+    expect(Setting::query()->where('key', AnalyticsSource::SETTING_KEY)->exists())->toBeFalse();
+});
+
+it('accepts google when a connection is available', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    $this->mock(AnalyticsSourceResolver::class, function ($mock) {
+        $mock->shouldReceive('isGoogleAvailable')->andReturn(true);
+        $mock->shouldReceive('set')->once()->with(AnalyticsSource::Google);
+    });
+
+    actingAs($admin)
+        ->post(route('dashboard.analytics.source.update'), ['source' => 'google'])
+        ->assertSessionHas('success');
+});

--- a/tests/Feature/Analytics/SourceSharedPropsTest.php
+++ b/tests/Feature/Analytics/SourceSharedPropsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Analytics\AnalyticsSource;
+use App\Analytics\AnalyticsSourceResolver;
+use App\Enums\Role;
+use App\Http\HandleInertiaRequests;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Modules\Core\Setting;
+
+function resolvedAnalyticsSourceProps(User $user): mixed
+{
+    $request = Request::create('/dashboard/analytics');
+    $request->setUserResolver(fn () => $user);
+
+    $shared = app(HandleInertiaRequests::class)->share($request);
+
+    $value = $shared['analyticsSource'] ?? null;
+
+    return is_callable($value) ? $value() : $value;
+}
+
+it('does not expose the analyticsSource prop to editors', function () {
+    $editor = User::factory()->create([
+        'role' => Role::Editor,
+        'email_verified_at' => now(),
+    ]);
+
+    expect(resolvedAnalyticsSourceProps($editor))->toBeNull();
+});
+
+it('exposes the current source and options to admins', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    Setting::updateOrCreate(
+        ['key' => AnalyticsSource::SETTING_KEY],
+        ['value' => AnalyticsSource::Google->value],
+    );
+
+    // Deterministic availability signal so we don't accidentally hit GA
+    // credentials or the connections table in the assertion.
+    $this->mock(AnalyticsSourceResolver::class, function ($mock) {
+        $mock->shouldReceive('active')->andReturn(AnalyticsSource::Google);
+        $mock->shouldReceive('isGoogleAvailable')->andReturn(true);
+    });
+
+    $props = resolvedAnalyticsSourceProps($admin);
+
+    expect($props)->toMatchArray([
+        'active' => 'google',
+        'options' => [
+            'local' => 'Local (first-party)',
+            'google' => 'Google Analytics',
+        ],
+        'google_available' => true,
+    ])
+        ->and($props['update_url'])->toBe(route('dashboard.analytics.source.update'));
+});
+
+it('defaults to local when no setting has been persisted yet', function () {
+    $admin = User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+
+    $props = resolvedAnalyticsSourceProps($admin);
+
+    expect($props['active'])->toBe('local');
+});


### PR DESCRIPTION
## Summary

Adds a per-site setting that flips every `/dashboard/analytics/*` page between the local first-party store and Google Analytics 4. The dropdown lives on the analytics sub-nav (single component, all six pages) and is gated to admins; selecting Google without a connected Google account is rejected with a link to the integration page.

- `DashboardDataSourceManager` extends the vendor `AnalyticsQuery` service and dispatches each dashboard-facing method to either the parent (local) or a private google-scoped `AnalyticsQuery` backed by a new `Ga4QueryProvider`. Container rebind in `AppServiceProvider` makes the vendor `InertiaDashboardController` pick it up transparently — no vendor code is touched.
- `Ga4QueryProvider` implements the vendor `AnalyticsQueryInterface` across all methods the dashboard calls and covers realtime through GA4's `runRealtimeReport` endpoint. Cache keys are namespaced with a `_source` filter so switching never surfaces the other provider's rows.
- POST `dashboard/analytics/source` behind `can:view-analytics` persists the choice to the `Setting` model; the active source + availability signal is exposed via a new `analyticsSource` Inertia shared prop scoped to admins.

## Test plan

- [x] `php artisan test tests/Feature/Analytics` — 14 new tests pass
- [x] `php artisan test tests/Feature/AnalyticsIntegrationTest.php tests/Feature/InertiaSharedPropsTest.php tests/Feature/DashboardTest.php` — 27 adjacent tests still pass
- [x] `npm run types` — clean
- [x] `vendor/bin/pint --dirty` — clean
- [x] Security review pass — no findings at confidence ≥ 7
- [ ] Manual: switch to Google as an admin with no connected account → warning banner appears and dropdown option is disabled
- [ ] Manual: switch to Google as an admin with a connected GA4 account → dashboard tiles, charts, top pages, traffic sources, audience breakdowns, events, and realtime all render GA4 data
- [ ] Manual: switch back to Local → dashboard tiles switch to the local store without surfacing stale GA4 cache

## Notes

- No `Setting` migration needed — the existing key/value table accepts the new `analytics_dashboard_source` key; the resolver falls back to `local` when unset.
- Livewire admin dashboard (`Modules/Admin/app/Livewire/Dashboard.php`) and `App\Services\GoogleAnalyticsService` are unchanged — they're already dead code per the separate cleanup issue.
- Branches off `release/3.0`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing between local analytics and Google Analytics.
  * Analytics dashboards now retrieve metrics, trends, breakdowns, and real-time data from the selected source.
  * Administrators can switch sources from the analytics navigation.
  * Added guidance when Google Analytics requires a connection.

* **Bug Fixes**
  * Analytics safely falls back to local data when Google Analytics is unavailable or misconfigured.

* **Tests**
  * Added coverage for source selection, permissions, shared settings, and Google Analytics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->