### PR TITLE
Rich admin dashboard with charts, sparklines, and role-aware payload

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,13 +4,366 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Analytics\AnalyticsSource;
+use App\Analytics\DashboardDataSourceManager;
+use App\Services\GoogleSearchConsoleService;
+use App\Services\NpmService;
+use App\Services\PackagistService;
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Packages\Package;
 
 class DashboardController extends Controller
 {
-    public function index(): Response
+    public function index(
+        Request $request,
+        PackagistService $packagist,
+        NpmService $npm,
+        AnalyticsQuery $analytics,
+        GoogleSearchConsoleService $searchConsole,
+    ): Response {
+        // Registry download counts, first-party/GA traffic, and Search
+        // Console data are gated behind `view-analytics` (admin-only)
+        // everywhere else in the app — the dashboard route itself only
+        // requires `auth+verified`, so mirror that gate here rather
+        // than surfacing the data to verified editors.
+        $canViewAnalytics = $request->user()?->can('view-analytics') ?? false;
+
+        $packages = Package::withCount('documentation')->orderBy('name')->get();
+
+        $packagistStats = $canViewAnalytics
+            ? $this->packagistStats($packagist, $packages)
+            : $this->emptyPackagistStats();
+
+        $npmStats = $canViewAnalytics
+            ? $this->npmStats($npm, $packages)
+            : $this->emptyNpmStats();
+
+        $needsReimport = $packages->filter(fn (Package $p) => $p->needsDocumentationReimport())->count();
+        $neverImported = $packages->whereNull('docs_imported_at')->count();
+        $upToDate = $packages->count() - $needsReimport;
+
+        return Inertia::render('Dashboard/Index', [
+            'can_view_analytics' => $canViewAnalytics,
+            'totals' => [
+                'packages' => $packages->count(),
+                'documentation' => (int) $packages->sum('documentation_count'),
+                'downloads' => $packagistStats['total'] + $npmStats['total'],
+                'monthly_downloads' => $packagistStats['monthly'] + $npmStats['monthly'],
+                'needs_reimport' => $needsReimport,
+                'up_to_date' => $upToDate,
+                'never_imported' => $neverImported,
+                'packagist_count' => $packages->filter(fn (Package $p) => $p->isPackagist())->count(),
+                'npm_count' => $packages->filter(fn (Package $p) => $p->isNpm())->count(),
+                'unlinked_count' => $packages->filter(fn (Package $p) => ! $p->isPackagist() && ! $p->isNpm())->count(),
+                'stars' => $packagistStats['stars'],
+            ],
+            'packages' => $packages->map(fn (Package $p) => $this->transformPackage($p))->values(),
+            'packagist' => $packagistStats,
+            'npm' => $npmStats,
+            'analytics' => $canViewAnalytics ? $this->analyticsPayload($analytics) : null,
+            'search_console' => $canViewAnalytics ? $this->searchConsolePayload($searchConsole) : null,
+            'registry_breakdown' => $this->registryBreakdown($packages),
+            'status_breakdown' => $this->statusBreakdown($upToDate, $needsReimport, $neverImported),
+            'top_documented' => $this->topDocumented($packages),
+            'recent_imports' => $this->recentImports($packages),
+            'docs_distribution' => $packages
+                ->sortByDesc('documentation_count')
+                ->pluck('documentation_count')
+                ->map(fn ($v) => (int) $v)
+                ->values()
+                ->all(),
+        ]);
+    }
+
+    /**
+     * @return array{is_configured: bool, monthly: int, daily: int, total: int, stars: int, top_packages: array<int, array{name: string, monthly: int, total: int}>}
+     */
+    private function emptyPackagistStats(): array
     {
-        return Inertia::render('Dashboard/Index');
+        return [
+            'is_configured' => false,
+            'monthly' => 0,
+            'daily' => 0,
+            'total' => 0,
+            'stars' => 0,
+            'top_packages' => [],
+        ];
+    }
+
+    /**
+     * @return array{is_configured: bool, monthly: int, weekly: int, total: int, top_packages: array<int, array{name: string, monthly: int, total: int}>}
+     */
+    private function emptyNpmStats(): array
+    {
+        return [
+            'is_configured' => false,
+            'monthly' => 0,
+            'weekly' => 0,
+            'total' => 0,
+            'top_packages' => [],
+        ];
+    }
+
+    /**
+     * @return array{id: int, name: string, slug: string, icon: ?string, version: ?string, docs_count: int, docs_imported_at: ?string, last_import_human: ?string, registry: ?string, registry_name: ?string, status: string}
+     */
+    private function transformPackage(Package $package): array
+    {
+        $status = 'up_to_date';
+        if ($package->docs_imported_at === null) {
+            $status = 'never';
+        } elseif ($package->needsDocumentationReimport()) {
+            $status = 'needs_update';
+        }
+
+        return [
+            'id' => $package->id,
+            'name' => $package->name,
+            'slug' => $package->slug,
+            'icon' => $package->icon,
+            'version' => $package->version,
+            'docs_count' => (int) $package->documentation_count,
+            'docs_imported_at' => $package->docs_imported_at?->toIso8601String(),
+            'last_import_human' => $package->docs_imported_at?->diffForHumans(),
+            'registry' => $package->package_registry,
+            'registry_name' => $package->getRegistryPackageName(),
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Package>  $packages
+     * @return array{is_configured: bool, monthly: int, daily: int, total: int, stars: int, top_packages: array<int, array{name: string, monthly: int, total: int}>}
+     */
+    private function packagistStats(PackagistService $service, Collection $packages): array
+    {
+        $names = $packages
+            ->filter(fn (Package $p) => $p->isPackagist())
+            ->map(fn (Package $p) => $p->getRegistryPackageName())
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($names === []) {
+            return [
+                'is_configured' => false,
+                'monthly' => 0,
+                'daily' => 0,
+                'total' => 0,
+                'stars' => 0,
+                'top_packages' => [],
+            ];
+        }
+
+        $stats = $service->getAggregatedStats($names);
+
+        $top = collect($stats['packages'] ?? [])
+            ->map(fn (array $data, string $name) => [
+                'name' => $name,
+                'monthly' => (int) ($data['downloads']['monthly'] ?? 0),
+                'total' => (int) ($data['downloads']['total'] ?? 0),
+            ])
+            ->sortByDesc('monthly')
+            ->take(5)
+            ->values()
+            ->all();
+
+        return [
+            'is_configured' => true,
+            'monthly' => (int) ($stats['monthly_downloads'] ?? 0),
+            'daily' => (int) ($stats['daily_downloads'] ?? 0),
+            'total' => (int) ($stats['total_downloads'] ?? 0),
+            'stars' => (int) ($stats['total_favers'] ?? 0),
+            'top_packages' => $top,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Package>  $packages
+     * @return array{is_configured: bool, monthly: int, weekly: int, total: int, top_packages: array<int, array{name: string, monthly: int, total: int}>}
+     */
+    private function npmStats(NpmService $service, Collection $packages): array
+    {
+        $names = $packages
+            ->filter(fn (Package $p) => $p->isNpm())
+            ->map(fn (Package $p) => $p->getRegistryPackageName())
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($names === []) {
+            return [
+                'is_configured' => false,
+                'monthly' => 0,
+                'weekly' => 0,
+                'total' => 0,
+                'top_packages' => [],
+            ];
+        }
+
+        $stats = $service->getAggregatedStats($names);
+
+        $top = collect($stats['packages'] ?? [])
+            ->map(fn (array $data, string $name) => [
+                'name' => $name,
+                'monthly' => (int) ($data['downloads']['monthly'] ?? 0),
+                'total' => (int) ($data['downloads']['total'] ?? 0),
+            ])
+            ->sortByDesc('monthly')
+            ->take(5)
+            ->values()
+            ->all();
+
+        return [
+            'is_configured' => true,
+            'monthly' => (int) ($stats['monthly_downloads'] ?? 0),
+            'weekly' => (int) ($stats['weekly_downloads'] ?? 0),
+            'total' => (int) ($stats['total_downloads'] ?? 0),
+            'top_packages' => $top,
+        ];
+    }
+
+    /**
+     * Build the analytics payload from the shared AnalyticsQuery service
+     * (which the container swaps for DashboardDataSourceManager, so the
+     * numbers reflect whichever source — first-party analytics or
+     * Google Analytics — is active in Settings).
+     */
+    private function analyticsPayload(AnalyticsQuery $analytics): array
+    {
+        $range = DateRange::last30Days();
+        $stats = $analytics->getStats($range, withCompare: false);
+        $topPages = $analytics->getTopPages($range, 5);
+
+        $source = $analytics instanceof DashboardDataSourceManager
+            ? $analytics->activeSource()
+            : AnalyticsSource::Local;
+
+        $avgSeconds = (int) round((float) ($stats['avg_session_duration'] ?? 0));
+
+        return [
+            'is_configured' => true,
+            'source' => $source->value,
+            'source_label' => $source === AnalyticsSource::Google
+                ? 'Google Analytics'
+                : 'First-party analytics',
+            'page_views' => (int) ($stats['pageviews'] ?? 0),
+            'sessions' => (int) ($stats['sessions'] ?? 0),
+            'users' => (int) ($stats['visitors'] ?? 0),
+            'bounce_rate' => number_format((float) ($stats['bounce_rate'] ?? 0), 1).'%',
+            'avg_session_duration' => $this->formatDuration($avgSeconds),
+            'top_pages' => $topPages
+                ->take(5)
+                ->map(fn (array $row) => [
+                    'page' => (string) ($row['path'] ?? '/'),
+                    'views' => (int) ($row['views'] ?? 0),
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+
+    /**
+     * Search Console has no fallback — return null when it isn't
+     * configured so the frontend can drop the panel entirely instead
+     * of rendering a "not configured" placeholder.
+     */
+    private function searchConsolePayload(GoogleSearchConsoleService $service): ?array
+    {
+        if (! $service->isConfigured()) {
+            return null;
+        }
+
+        $overview = $service->getOverview(28);
+
+        return [
+            'clicks' => (int) ($overview['clicks'] ?? 0),
+            'impressions' => (int) ($overview['impressions'] ?? 0),
+            'ctr' => $overview['ctr'] ?? '0%',
+            'position' => (float) ($overview['position'] ?? 0),
+            'top_queries' => $service->getTopQueries(5, 28),
+        ];
+    }
+
+    private function formatDuration(int $seconds): string
+    {
+        if ($seconds < 60) {
+            return "{$seconds}s";
+        }
+
+        $minutes = intdiv($seconds, 60);
+        $remainder = $seconds % 60;
+
+        return "{$minutes}m {$remainder}s";
+    }
+
+    /**
+     * @param  Collection<int, Package>  $packages
+     * @return array<int, array{label: string, value: int}>
+     */
+    private function registryBreakdown(Collection $packages): array
+    {
+        return [
+            ['label' => 'Packagist', 'value' => $packages->filter(fn (Package $p) => $p->isPackagist())->count()],
+            ['label' => 'NPM', 'value' => $packages->filter(fn (Package $p) => $p->isNpm())->count()],
+            ['label' => 'Unlinked', 'value' => $packages->filter(fn (Package $p) => ! $p->isPackagist() && ! $p->isNpm())->count()],
+        ];
+    }
+
+    /**
+     * @return array<int, array{label: string, value: int}>
+     */
+    private function statusBreakdown(int $upToDate, int $needsReimport, int $neverImported): array
+    {
+        $needsUpdateOnly = max(0, $needsReimport - $neverImported);
+
+        return [
+            ['label' => 'Up to date', 'value' => $upToDate],
+            ['label' => 'Needs update', 'value' => $needsUpdateOnly],
+            ['label' => 'Never imported', 'value' => $neverImported],
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Package>  $packages
+     * @return array<int, array{name: string, docs_count: int, slug: string}>
+     */
+    private function topDocumented(Collection $packages): array
+    {
+        return $packages
+            ->sortByDesc('documentation_count')
+            ->take(6)
+            ->map(fn (Package $p) => [
+                'name' => $p->name,
+                'slug' => $p->slug,
+                'docs_count' => (int) $p->documentation_count,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, Package>  $packages
+     * @return array<int, array{name: string, slug: string, last_import_human: string, imported_at: string}>
+     */
+    private function recentImports(Collection $packages): array
+    {
+        return $packages
+            ->filter(fn (Package $p) => $p->docs_imported_at !== null)
+            ->sortByDesc('docs_imported_at')
+            ->take(6)
+            ->map(fn (Package $p) => [
+                'name' => $p->name,
+                'slug' => $p->slug,
+                'imported_at' => $p->docs_imported_at->toIso8601String(),
+                'last_import_human' => $p->docs_imported_at->diffForHumans(),
+            ])
+            ->values()
+            ->all();
     }
 }

--- a/resources/js/pages/Dashboard/Index.tsx
+++ b/resources/js/pages/Dashboard/Index.tsx
@@ -1,27 +1,924 @@
-import { Head } from '@inertiajs/react';
-import { Card } from '@artisanpack-ui/react/layout';
+import { Head, Link } from '@inertiajs/react';
+import { Sparkline } from '@artisanpack-ui/react/data';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { AdminLayout } from '../../layouts/AdminLayout';
+import { DashChart } from './components/DashChart';
 
-export default function DashboardIndex() {
+interface PackageRow {
+    id: number;
+    name: string;
+    slug: string;
+    icon: string | null;
+    version: string | null;
+    docs_count: number;
+    docs_imported_at: string | null;
+    last_import_human: string | null;
+    registry: 'packagist' | 'npm' | null;
+    registry_name: string | null;
+    status: 'up_to_date' | 'needs_update' | 'never';
+}
+
+interface Totals {
+    packages: number;
+    documentation: number;
+    downloads: number;
+    monthly_downloads: number;
+    needs_reimport: number;
+    up_to_date: number;
+    never_imported: number;
+    packagist_count: number;
+    npm_count: number;
+    unlinked_count: number;
+    stars: number;
+}
+
+interface PackagistStats {
+    is_configured: boolean;
+    monthly: number;
+    daily: number;
+    total: number;
+    stars: number;
+    top_packages: Array<{ name: string; monthly: number; total: number }>;
+}
+
+interface NpmStats {
+    is_configured: boolean;
+    monthly: number;
+    weekly: number;
+    total: number;
+    top_packages: Array<{ name: string; monthly: number; total: number }>;
+}
+
+interface AnalyticsPayload {
+    is_configured: boolean;
+    source: 'local' | 'google';
+    source_label: string;
+    page_views: number;
+    sessions: number;
+    users: number;
+    avg_session_duration: string;
+    bounce_rate: string;
+    top_pages: Array<{ page: string; views: number }>;
+}
+
+interface SearchConsolePayload {
+    clicks: number;
+    impressions: number;
+    ctr: string;
+    position: number;
+    top_queries: Array<{
+        query: string;
+        clicks: number;
+        impressions: number;
+        ctr: string;
+        position: number;
+    }>;
+}
+
+interface Breakdown {
+    label: string;
+    value: number;
+}
+
+interface TopDocumented {
+    name: string;
+    slug: string;
+    docs_count: number;
+}
+
+interface RecentImport {
+    name: string;
+    slug: string;
+    imported_at: string;
+    last_import_human: string;
+}
+
+interface DashboardPageProps {
+    can_view_analytics: boolean;
+    totals: Totals;
+    packages: PackageRow[];
+    packagist: PackagistStats;
+    npm: NpmStats;
+    analytics: AnalyticsPayload | null;
+    search_console: SearchConsolePayload | null;
+    registry_breakdown: Breakdown[];
+    status_breakdown: Breakdown[];
+    top_documented: TopDocumented[];
+    recent_imports: RecentImport[];
+    docs_distribution: number[];
+}
+
+type GradientToken =
+    | 'primary-accent'
+    | 'primary-secondary'
+    | 'secondary-primary'
+    | 'secondary-accent'
+    | 'accent-primary'
+    | 'accent-secondary'
+    | 'neon';
+
+function gradientStyle(token: GradientToken): CSSProperties {
+    const grad = token === 'neon' ? 'var(--grad-neon)' : `var(--grad-${token})`;
+
+    return {
+        background: `linear-gradient(var(--color-surface-2), var(--color-surface-2)) padding-box, ${grad} border-box`,
+    };
+}
+
+function formatNumber(value: number): string {
+    if (value >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(1)}M`;
+    }
+    if (value >= 1_000) {
+        return `${(value / 1_000).toFixed(1)}K`;
+    }
+    return value.toLocaleString();
+}
+
+interface GradientFrameProps {
+    gradient: GradientToken;
+    className?: string;
+    children: ReactNode;
+}
+
+function GradientFrame({ gradient, className = '', children }: GradientFrameProps) {
+    return (
+        <div
+            className={`rounded-box border border-transparent ${className}`.trim()}
+            style={gradientStyle(gradient)}
+        >
+            {children}
+        </div>
+    );
+}
+
+interface StatCardProps {
+    label: string;
+    value: ReactNode;
+    hint?: ReactNode;
+    accent: 'primary' | 'secondary' | 'accent' | 'warning' | 'success';
+    gradient: GradientToken;
+    sparklineData?: number[];
+    sparklineType?: 'line' | 'area' | 'bar';
+}
+
+function StatCard({
+    label,
+    value,
+    hint,
+    accent,
+    gradient,
+    sparklineData,
+    sparklineType = 'area',
+}: StatCardProps) {
+    return (
+        <GradientFrame gradient={gradient}>
+            <div className="flex flex-col gap-2 p-5">
+                <span className="text-xsmall font-medium uppercase tracking-[0.12em] text-text-subtle">
+                    {label}
+                </span>
+                <span
+                    className={`font-display text-h3 leading-none tabular-nums text-${accent}`}
+                >
+                    {value}
+                </span>
+                {hint ? (
+                    <span className="text-xsmall text-text-muted">{hint}</span>
+                ) : null}
+                {sparklineData && sparklineData.length > 1 ? (
+                    <div className="mt-1">
+                        <Sparkline
+                            data={sparklineData}
+                            type={sparklineType}
+                            color={accent}
+                            height={36}
+                            width={220}
+                            showTooltip={false}
+                        />
+                    </div>
+                ) : null}
+            </div>
+        </GradientFrame>
+    );
+}
+
+interface PanelProps {
+    gradient: GradientToken;
+    title: string;
+    description?: string;
+    actions?: ReactNode;
+    children: ReactNode;
+    padded?: boolean;
+    className?: string;
+}
+
+function Panel({
+    gradient,
+    title,
+    description,
+    actions,
+    children,
+    padded = true,
+    className = '',
+}: PanelProps) {
+    return (
+        <GradientFrame gradient={gradient} className={className}>
+            <header className="flex items-start justify-between gap-4 border-b border-border-subtle/60 px-6 py-4">
+                <div className="flex flex-col gap-1">
+                    <h2 className="font-display text-h6 text-text">{title}</h2>
+                    {description ? (
+                        <p className="text-xsmall text-text-muted">{description}</p>
+                    ) : null}
+                </div>
+                {actions ? <div className="flex shrink-0 gap-2">{actions}</div> : null}
+            </header>
+            <div className={padded ? 'p-6' : ''}>{children}</div>
+        </GradientFrame>
+    );
+}
+
+function StatusBadge({ status }: { status: PackageRow['status'] }) {
+    if (status === 'up_to_date') {
+        return (
+            <span className="inline-flex items-center rounded-full bg-success/15 px-2.5 py-0.5 text-xsmall font-medium text-success">
+                Up to date
+            </span>
+        );
+    }
+    if (status === 'needs_update') {
+        return (
+            <span className="inline-flex items-center rounded-full bg-warning/15 px-2.5 py-0.5 text-xsmall font-medium text-warning">
+                Needs update
+            </span>
+        );
+    }
+    return (
+        <span className="inline-flex items-center rounded-full bg-error/15 px-2.5 py-0.5 text-xsmall font-medium text-error">
+            Never imported
+        </span>
+    );
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+    return (
+        <div className="flex flex-col items-center justify-center gap-1 py-6 text-center">
+            <p className="text-small text-text-muted">{title}</p>
+            <p className="text-xsmall text-text-subtle">{description}</p>
+        </div>
+    );
+}
+
+function KeyValueRow({ label, value }: { label: ReactNode; value: ReactNode }) {
+    return (
+        <div className="flex items-center justify-between border-b border-border-subtle/40 py-2 last:border-b-0">
+            <span className="text-small text-text-muted">{label}</span>
+            <span className="text-small font-semibold tabular-nums text-text">
+                {value}
+            </span>
+        </div>
+    );
+}
+
+export default function DashboardIndex(props: DashboardPageProps) {
+    const {
+        can_view_analytics: canViewAnalytics,
+        totals,
+        packages,
+        packagist,
+        npm,
+        analytics,
+        search_console: searchConsole,
+        registry_breakdown: registryBreakdown,
+        status_breakdown: statusBreakdown,
+        top_documented: topDocumented,
+        recent_imports: recentImports,
+        docs_distribution: docsDistribution,
+    } = props;
+
+    const sparklinePad = docsDistribution.length > 1 ? docsDistribution : [0, 0];
+    const statusPad = statusBreakdown.map((b) => b.value);
+    const topPackagesForDownloads = [...packagist.top_packages, ...npm.top_packages]
+        .sort((a, b) => b.monthly - a.monthly)
+        .slice(0, 8);
+
     return (
         <AdminLayout title="Dashboard">
             <Head title="Dashboard" />
 
-            <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-                <header>
-                    <p className="text-small text-text-muted">
-                        Manage packages, pages, and site settings from a single place.
-                    </p>
+            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+                <header className="flex flex-wrap items-end justify-between gap-3">
+                    <div>
+                        <h1 className="font-display text-h3 text-text">Dashboard</h1>
+                        <p className="text-small text-text-muted">
+                            A live snapshot of every package, download, and visitor across the docs site.
+                        </p>
+                    </div>
+                    <div className="flex gap-2">
+                        <Link
+                            href="/dashboard/packages"
+                            className="rounded-[8px] border border-border-subtle bg-surface px-3 py-1.5 text-small text-text-muted transition hover:border-primary hover:text-text"
+                        >
+                            Manage packages
+                        </Link>
+                        <Link
+                            href="/dashboard/analytics"
+                            className="rounded-[8px] border border-transparent px-3 py-1.5 text-small text-text"
+                            style={gradientStyle('neon')}
+                        >
+                            View analytics
+                        </Link>
+                    </div>
                 </header>
 
-                <Card>
-                    <h2 className="mb-2 font-display text-h6">Welcome back</h2>
-                    <p className="text-small text-text-muted">
-                        Use the sidebar to navigate the admin area. Package, documentation,
-                        and page management ship in upcoming releases.
-                    </p>
-                </Card>
+                {/* Row 1: primary stat tiles with sparklines */}
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <StatCard
+                        label="Total Packages"
+                        value={totals.packages.toLocaleString()}
+                        hint={`${totals.packagist_count} Packagist · ${totals.npm_count} NPM`}
+                        accent="primary"
+                        gradient="primary-accent"
+                        sparklineData={sparklinePad}
+                        sparklineType="bar"
+                    />
+                    <StatCard
+                        label="Documentation Pages"
+                        value={totals.documentation.toLocaleString()}
+                        hint={
+                            totals.packages > 0
+                                ? `${Math.round(totals.documentation / totals.packages)} avg per package`
+                                : 'No packages yet'
+                        }
+                        accent="secondary"
+                        gradient="secondary-accent"
+                        sparklineData={sparklinePad}
+                        sparklineType="area"
+                    />
+                    {canViewAnalytics ? (
+                        <StatCard
+                            label="Total Downloads"
+                            value={formatNumber(totals.downloads)}
+                            hint={`${formatNumber(totals.monthly_downloads)} this month · Packagist + NPM`}
+                            accent="accent"
+                            gradient="primary-secondary"
+                            sparklineData={
+                                topPackagesForDownloads.length > 1
+                                    ? topPackagesForDownloads.map((p) => p.monthly)
+                                    : [0, 0]
+                            }
+                            sparklineType="line"
+                        />
+                    ) : (
+                        <StatCard
+                            label="Coverage"
+                            value={
+                                totals.packages > 0
+                                    ? `${Math.round((totals.up_to_date / totals.packages) * 100)}%`
+                                    : '—'
+                            }
+                            hint={`${totals.up_to_date} of ${totals.packages} up to date`}
+                            accent={totals.needs_reimport > 0 ? 'warning' : 'success'}
+                            gradient="primary-secondary"
+                        />
+                    )}
+                    <StatCard
+                        label="Needs Re-import"
+                        value={totals.needs_reimport.toLocaleString()}
+                        hint={
+                            totals.needs_reimport > 0
+                                ? 'Packages with stale or missing docs'
+                                : 'All packages fresh'
+                        }
+                        accent={totals.needs_reimport > 0 ? 'warning' : 'success'}
+                        gradient="secondary-primary"
+                        sparklineData={statusPad.length > 1 ? statusPad : [0, 0]}
+                        sparklineType="bar"
+                    />
+                </div>
+
+                {/* Row 2: download-scoped stats (admins only) */}
+                {canViewAnalytics ? (
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <StatCard
+                            label="Packagist Monthly"
+                            value={formatNumber(packagist.monthly)}
+                            hint={`${formatNumber(packagist.daily)} / day`}
+                            accent="primary"
+                            gradient="accent-primary"
+                        />
+                        <StatCard
+                            label="NPM Monthly"
+                            value={formatNumber(npm.monthly)}
+                            hint={`${formatNumber(npm.weekly)} / week`}
+                            accent="secondary"
+                            gradient="accent-secondary"
+                        />
+                        <StatCard
+                            label="Stars"
+                            value={formatNumber(totals.stars)}
+                            hint="Across all linked Packagist packages"
+                            accent="accent"
+                            gradient="primary-accent"
+                        />
+                        <StatCard
+                            label="Coverage"
+                            value={
+                                totals.packages > 0
+                                    ? `${Math.round((totals.up_to_date / totals.packages) * 100)}%`
+                                    : '—'
+                            }
+                            hint={`${totals.up_to_date} of ${totals.packages} up to date`}
+                            accent={totals.needs_reimport > 0 ? 'warning' : 'success'}
+                            gradient="secondary-accent"
+                        />
+                    </div>
+                ) : null}
+
+                {/* Row 3: monthly downloads (admins) + registry mix */}
+                <div className="grid gap-6 lg:grid-cols-3">
+                    {canViewAnalytics ? (
+                        <Panel
+                            gradient="primary-accent"
+                            title="Monthly downloads"
+                            description="Top-performing packages across Packagist & NPM this month."
+                            className="lg:col-span-2"
+                        >
+                            {topPackagesForDownloads.length > 0 ? (
+                                <DashChart
+                                    type="bar"
+                                    labels={topPackagesForDownloads.map((p) =>
+                                        p.name.replace(/^@?artisanpack-ui\//, ''),
+                                    )}
+                                    series={[
+                                        {
+                                            name: 'Monthly downloads',
+                                            data: topPackagesForDownloads.map((p) => p.monthly),
+                                        },
+                                    ]}
+                                    color="primary"
+                                    height={280}
+                                    showLegend={false}
+                                />
+                            ) : (
+                                <EmptyState
+                                    title="No download data available"
+                                    description="Link packages to Packagist or NPM to see monthly download trends."
+                                />
+                            )}
+                        </Panel>
+                    ) : null}
+                    <Panel
+                        gradient="secondary-accent"
+                        title="Registry mix"
+                        description="How packages are distributed across registries."
+                        className={canViewAnalytics ? '' : 'lg:col-span-3'}
+                    >
+                        {totals.packages > 0 ? (
+                            <DashChart
+                                type="donut"
+                                data={registryBreakdown.map((row, index) => ({
+                                    label: row.label,
+                                    value: row.value,
+                                    color: (
+                                        ['primary', 'secondary', 'accent'] as const
+                                    )[index % 3],
+                                }))}
+                                height={280}
+                            />
+                        ) : (
+                            <EmptyState
+                                title="No packages linked"
+                                description="Add a package to populate the registry breakdown."
+                            />
+                        )}
+                    </Panel>
+                </div>
+
+                {/* Row 4: status donut + top documented bar + docs distribution area */}
+                <div className="grid gap-6 lg:grid-cols-3">
+                    <Panel
+                        gradient="accent-primary"
+                        title="Documentation status"
+                        description="Freshness of imported docs across all packages."
+                    >
+                        {totals.packages > 0 ? (
+                            <DashChart
+                                type="donut"
+                                data={statusBreakdown.map((row) => ({
+                                    label: row.label,
+                                    value: row.value,
+                                    color:
+                                        row.label === 'Up to date'
+                                            ? 'success'
+                                            : row.label === 'Needs update'
+                                              ? 'warning'
+                                              : 'error',
+                                }))}
+                                height={280}
+                            />
+                        ) : (
+                            <EmptyState
+                                title="Nothing to score yet"
+                                description="Once packages are added, freshness lands here."
+                            />
+                        )}
+                    </Panel>
+                    <Panel
+                        gradient="accent-secondary"
+                        title="Most documented packages"
+                        description="Top 6 packages ranked by doc page count."
+                    >
+                        {topDocumented.length > 0 ? (
+                            <DashChart
+                                type="bar"
+                                labels={topDocumented.map((p) => p.name)}
+                                series={[
+                                    {
+                                        name: 'Docs',
+                                        data: topDocumented.map((p) => p.docs_count),
+                                    },
+                                ]}
+                                color="secondary"
+                                height={280}
+                                showLegend={false}
+                                horizontal
+                            />
+                        ) : (
+                            <EmptyState
+                                title="No documentation yet"
+                                description="Import docs to see the leaderboard."
+                            />
+                        )}
+                    </Panel>
+                    <Panel
+                        gradient="primary-secondary"
+                        title="Docs distribution"
+                        description="Doc counts per package, sorted descending."
+                    >
+                        {sparklinePad.some((v) => v > 0) ? (
+                            <DashChart
+                                type="area"
+                                labels={docsDistribution.map((_, i) => String(i + 1))}
+                                series={[
+                                    {
+                                        name: 'Docs per package',
+                                        data: docsDistribution,
+                                    },
+                                ]}
+                                color="accent"
+                                height={280}
+                                showLegend={false}
+                            />
+                        ) : (
+                            <EmptyState
+                                title="No distribution data"
+                                description="Docs will populate this chart once imported."
+                            />
+                        )}
+                    </Panel>
+                </div>
+
+                {/* Row 5: main packages table + Packagist/NPM columns (admins only) */}
+                <div
+                    className={`grid gap-6 ${
+                        canViewAnalytics ? 'lg:grid-cols-3' : ''
+                    }`}
+                >
+                    <Panel
+                        gradient="neon"
+                        title="Packages overview"
+                        description={`All ${totals.packages} packages with documentation status.`}
+                        className={canViewAnalytics ? 'lg:col-span-2' : ''}
+                        padded={false}
+                        actions={
+                            <Link
+                                href="/dashboard/packages/create"
+                                className="rounded-[8px] border border-transparent px-3 py-1.5 text-xsmall font-medium text-text"
+                                style={gradientStyle('primary-accent')}
+                            >
+                                + Add package
+                            </Link>
+                        }
+                    >
+                        <div className="max-h-[520px] overflow-auto">
+                            <table className="w-full text-left text-small">
+                                <thead className="sticky top-0 z-10 border-b border-border-subtle/60 bg-surface-2 text-xsmall uppercase tracking-[0.08em] text-text-subtle">
+                                    <tr>
+                                        <th className="px-5 py-3 font-medium">Package</th>
+                                        <th className="px-5 py-3 text-center font-medium">Version</th>
+                                        <th className="px-5 py-3 text-center font-medium">Docs</th>
+                                        <th className="px-5 py-3 text-center font-medium">Last import</th>
+                                        <th className="px-5 py-3 text-right font-medium">Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {packages.length === 0 ? (
+                                        <tr>
+                                            <td
+                                                colSpan={5}
+                                                className="px-5 py-8 text-center text-text-muted"
+                                            >
+                                                No packages yet.{' '}
+                                                <Link
+                                                    href="/dashboard/packages/create"
+                                                    className="text-primary underline-offset-2 hover:underline"
+                                                >
+                                                    Add your first package
+                                                </Link>
+                                                .
+                                            </td>
+                                        </tr>
+                                    ) : (
+                                        packages.map((pkg) => (
+                                            <tr
+                                                key={pkg.id}
+                                                className="border-b border-border-subtle/40 last:border-b-0 hover:bg-surface/60"
+                                            >
+                                                <td className="px-5 py-3">
+                                                    <div className="flex flex-col gap-0.5">
+                                                        <span className="font-medium text-text">
+                                                            {pkg.name}
+                                                        </span>
+                                                        {pkg.registry_name ? (
+                                                            <span className="font-mono text-xsmall text-text-subtle">
+                                                                {pkg.registry_name}
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
+                                                </td>
+                                                <td className="px-5 py-3 text-center">
+                                                    {pkg.version ? (
+                                                        <span className="rounded-full border border-border-subtle px-2 py-0.5 text-xsmall font-mono text-text-muted">
+                                                            {pkg.version}
+                                                        </span>
+                                                    ) : (
+                                                        <span className="text-text-subtle">—</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-3 text-center font-semibold tabular-nums text-text">
+                                                    {pkg.docs_count}
+                                                </td>
+                                                <td className="px-5 py-3 text-center text-text-muted">
+                                                    {pkg.last_import_human ?? (
+                                                        <span className="text-text-subtle">Never</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-3 text-right">
+                                                    <StatusBadge status={pkg.status} />
+                                                </td>
+                                            </tr>
+                                        ))
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </Panel>
+
+                    {canViewAnalytics ? (
+                    <div className="flex flex-col gap-6">
+                        <Panel
+                            gradient="primary-secondary"
+                            title="Packagist"
+                            description="Composer package downloads"
+                        >
+                            {packagist.is_configured ? (
+                                <div className="flex flex-col gap-1">
+                                    <KeyValueRow
+                                        label="Monthly"
+                                        value={formatNumber(packagist.monthly)}
+                                    />
+                                    <KeyValueRow
+                                        label="Daily"
+                                        value={formatNumber(packagist.daily)}
+                                    />
+                                    <KeyValueRow
+                                        label="Total"
+                                        value={formatNumber(packagist.total)}
+                                    />
+                                    <KeyValueRow
+                                        label="Stars"
+                                        value={formatNumber(packagist.stars)}
+                                    />
+                                    {packagist.top_packages.length > 0 ? (
+                                        <div className="mt-4 flex flex-col gap-2">
+                                            <span className="text-xsmall uppercase tracking-[0.1em] text-text-subtle">
+                                                Top packages
+                                            </span>
+                                            {packagist.top_packages.slice(0, 3).map((p) => (
+                                                <div
+                                                    key={p.name}
+                                                    className="flex items-center justify-between text-xsmall"
+                                                >
+                                                    <span className="truncate font-mono text-text-muted">
+                                                        {p.name}
+                                                    </span>
+                                                    <span className="font-semibold tabular-nums text-text">
+                                                        {formatNumber(p.monthly)}
+                                                    </span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            ) : (
+                                <EmptyState
+                                    title="No Packagist packages linked"
+                                    description="Set a package's registry to Packagist to see stats."
+                                />
+                            )}
+                        </Panel>
+
+                        <Panel
+                            gradient="primary-accent"
+                            title="NPM"
+                            description="JavaScript package downloads"
+                        >
+                            {npm.is_configured ? (
+                                <div className="flex flex-col gap-1">
+                                    <KeyValueRow
+                                        label="Monthly"
+                                        value={formatNumber(npm.monthly)}
+                                    />
+                                    <KeyValueRow
+                                        label="Weekly"
+                                        value={formatNumber(npm.weekly)}
+                                    />
+                                    <KeyValueRow
+                                        label="Total"
+                                        value={formatNumber(npm.total)}
+                                    />
+                                    {npm.top_packages.length > 0 ? (
+                                        <div className="mt-4 flex flex-col gap-2">
+                                            <span className="text-xsmall uppercase tracking-[0.1em] text-text-subtle">
+                                                Top packages
+                                            </span>
+                                            {npm.top_packages.slice(0, 3).map((p) => (
+                                                <div
+                                                    key={p.name}
+                                                    className="flex items-center justify-between text-xsmall"
+                                                >
+                                                    <span className="truncate font-mono text-text-muted">
+                                                        {p.name}
+                                                    </span>
+                                                    <span className="font-semibold tabular-nums text-text">
+                                                        {formatNumber(p.monthly)}
+                                                    </span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            ) : (
+                                <EmptyState
+                                    title="No NPM packages linked"
+                                    description="Set a package's registry to NPM to see stats."
+                                />
+                            )}
+                        </Panel>
+                    </div>
+                    ) : null}
+                </div>
+
+                {/* Row 6: analytics (admins) + (optional) search console + recent imports */}
+                <div
+                    className={`grid gap-6 ${
+                        analytics && searchConsole
+                            ? 'lg:grid-cols-3'
+                            : 'lg:grid-cols-2'
+                    }`}
+                >
+                    {analytics ? (
+                    <Panel
+                        gradient="secondary-primary"
+                        title="Site analytics"
+                        description={`Last 30 days · ${analytics.source_label}`}
+                    >
+                        <div className="flex flex-col gap-1">
+                            <KeyValueRow
+                                label="Page views"
+                                value={formatNumber(analytics.page_views)}
+                            />
+                            <KeyValueRow
+                                label="Sessions"
+                                value={formatNumber(analytics.sessions)}
+                            />
+                            <KeyValueRow
+                                label={
+                                    analytics.source === 'google' ? 'Users' : 'Visitors'
+                                }
+                                value={formatNumber(analytics.users)}
+                            />
+                            <KeyValueRow
+                                label="Avg. session"
+                                value={analytics.avg_session_duration}
+                            />
+                            <KeyValueRow
+                                label="Bounce rate"
+                                value={analytics.bounce_rate}
+                            />
+                            {analytics.top_pages.length > 0 ? (
+                                <div className="mt-4 flex flex-col gap-2">
+                                    <span className="text-xsmall uppercase tracking-[0.1em] text-text-subtle">
+                                        Top pages
+                                    </span>
+                                    {analytics.top_pages.slice(0, 3).map((page) => (
+                                        <div
+                                            key={page.page}
+                                            className="flex items-center justify-between gap-3 text-xsmall"
+                                        >
+                                            <span className="truncate font-mono text-text-muted">
+                                                {page.page}
+                                            </span>
+                                            <span className="font-semibold tabular-nums text-text">
+                                                {formatNumber(page.views)}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : null}
+                        </div>
+                    </Panel>
+                    ) : null}
+
+                    {searchConsole ? (
+                        <Panel
+                            gradient="accent-secondary"
+                            title="Search Console"
+                            description="Last 28 days"
+                        >
+                            <div className="flex flex-col gap-1">
+                                <KeyValueRow
+                                    label="Clicks"
+                                    value={formatNumber(searchConsole.clicks)}
+                                />
+                                <KeyValueRow
+                                    label="Impressions"
+                                    value={formatNumber(searchConsole.impressions)}
+                                />
+                                <KeyValueRow label="CTR" value={searchConsole.ctr} />
+                                <KeyValueRow
+                                    label="Avg. position"
+                                    value={searchConsole.position.toFixed(1)}
+                                />
+                                {searchConsole.top_queries.length > 0 ? (
+                                    <div className="mt-4 flex flex-col gap-2">
+                                        <span className="text-xsmall uppercase tracking-[0.1em] text-text-subtle">
+                                            Top queries
+                                        </span>
+                                        {searchConsole.top_queries.slice(0, 3).map((q) => (
+                                            <div
+                                                key={q.query}
+                                                className="flex items-center justify-between gap-3 text-xsmall"
+                                            >
+                                                <span className="truncate text-text-muted">
+                                                    {q.query}
+                                                </span>
+                                                <span className="font-semibold tabular-nums text-text">
+                                                    {formatNumber(q.clicks)}
+                                                </span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                ) : null}
+                            </div>
+                        </Panel>
+                    ) : null}
+
+                    <Panel
+                        gradient="primary-accent"
+                        title="Recent imports"
+                        description="Latest doc imports across the fleet."
+                    >
+                        {recentImports.length > 0 ? (
+                            <ul className="flex flex-col gap-3">
+                                {recentImports.map((item) => (
+                                    <li
+                                        key={item.slug}
+                                        className="flex items-start justify-between gap-3 border-b border-border-subtle/40 pb-3 last:border-b-0 last:pb-0"
+                                    >
+                                        <div className="flex flex-col">
+                                            <span className="text-small font-medium text-text">
+                                                {item.name}
+                                            </span>
+                                            <span className="font-mono text-xsmall text-text-subtle">
+                                                {item.slug}
+                                            </span>
+                                        </div>
+                                        <span className="whitespace-nowrap text-xsmall text-text-muted">
+                                            {item.last_import_human}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <EmptyState
+                                title="No imports yet"
+                                description="Trigger an import from any package to see activity."
+                            />
+                        )}
+                    </Panel>
+                </div>
             </div>
         </AdminLayout>
     );

--- a/resources/js/pages/Dashboard/components/DashChart.tsx
+++ b/resources/js/pages/Dashboard/components/DashChart.tsx
@@ -1,0 +1,228 @@
+import { useMemo } from 'react';
+import ReactApexChart from 'react-apexcharts';
+import type { ApexOptions } from 'apexcharts';
+
+/**
+ * Local Chart wrapper mirroring the small subset of the
+ * `@artisanpack-ui/react/chart` API used by the dashboard. The vendor
+ * component's pre-built ESM chunk imports `react-apexcharts` in a way
+ * that trips ESM/CJS default-interop under Vite ("Element type is
+ * invalid… Check the render method of `Chart`."); the local wrapper
+ * imports `react-apexcharts` directly the same way the analytics
+ * dashboard does, which Vite handles correctly.
+ */
+export type DashChartType = 'bar' | 'line' | 'area' | 'donut' | 'pie';
+
+type SemanticColor =
+    | 'primary'
+    | 'secondary'
+    | 'accent'
+    | 'success'
+    | 'warning'
+    | 'error'
+    | 'info'
+    | 'neutral';
+
+export interface DashChartDataPoint {
+    label: string;
+    value: number;
+    color?: SemanticColor | string;
+}
+
+export interface DashChartSeries {
+    name: string;
+    data: number[];
+    color?: SemanticColor | string;
+}
+
+export interface DashChartProps {
+    type: DashChartType;
+    labels?: string[];
+    series?: DashChartSeries[];
+    data?: DashChartDataPoint[];
+    height?: number | string;
+    color?: SemanticColor;
+    showLegend?: boolean;
+    horizontal?: boolean;
+}
+
+const semanticToHex: Record<SemanticColor, string> = {
+    primary: '#6366f1',
+    secondary: '#a855f7',
+    accent: '#06b6d4',
+    success: '#22c55e',
+    warning: '#f59e0b',
+    error: '#ef4444',
+    info: '#3b82f6',
+    neutral: '#64748b',
+};
+
+const defaultPalette = [
+    '#6366f1',
+    '#a855f7',
+    '#06b6d4',
+    '#22c55e',
+    '#f59e0b',
+    '#ef4444',
+    '#3b82f6',
+    '#64748b',
+];
+
+function resolveColor(color: string | undefined, index: number): string {
+    if (!color) {
+        return defaultPalette[index % defaultPalette.length]!;
+    }
+    if (color in semanticToHex) {
+        return semanticToHex[color as SemanticColor];
+    }
+    return color;
+}
+
+export function DashChart({
+    type,
+    labels = [],
+    series = [],
+    data = [],
+    height = 300,
+    color,
+    showLegend = true,
+    horizontal = false,
+}: DashChartProps) {
+    const isPie = type === 'pie' || type === 'donut';
+
+    const resolvedColors = useMemo(() => {
+        if (isPie && data.length > 0) {
+            return data.map((d, i) => resolveColor(d.color as string | undefined, i));
+        }
+        if (series.length > 0) {
+            return series.map((s, i) =>
+                resolveColor((s.color as string | undefined) ?? color, i),
+            );
+        }
+        return [resolveColor(color, 0)];
+    }, [isPie, data, series, color]);
+
+    const apexSeries = useMemo(() => {
+        if (isPie) {
+            if (data.length > 0) return data.map((d) => d.value);
+            if (series.length > 0 && series[0]) return series[0].data;
+            return [];
+        }
+        if (series.length > 0) {
+            return series.map((s) => ({ name: s.name, data: s.data }));
+        }
+        if (data.length > 0) {
+            return [{ name: 'Value', data: data.map((d) => d.value) }];
+        }
+        return [];
+    }, [isPie, series, data]);
+
+    const apexLabels = useMemo(() => {
+        if (labels.length > 0) return labels;
+        if (data.length > 0) return data.map((d) => d.label);
+        return [];
+    }, [labels, data]);
+
+    const options = useMemo<ApexOptions>(() => {
+        const base: ApexOptions = {
+            chart: {
+                type,
+                toolbar: { show: false },
+                zoom: { enabled: false },
+                background: 'transparent',
+                fontFamily: 'inherit',
+                animations: { enabled: true, easing: 'easeout', speed: 250 },
+            },
+            colors: resolvedColors,
+            dataLabels: { enabled: false },
+            legend: {
+                show: showLegend,
+                position: 'bottom',
+                fontSize: '12px',
+                labels: { colors: 'var(--color-text-muted)' },
+            },
+            tooltip: { theme: 'dark' },
+        };
+
+        // Pie/donut charts choke on cartesian defaults (xaxis, yaxis,
+        // grid) — ApexCharts asserts `config.xaxis.convertedCatToNumeric`
+        // exists during pie rendering and blows up if we pass `xaxis:
+        // undefined`. Keep the config strictly to pie-relevant keys.
+        if (isPie) {
+            return {
+                ...base,
+                labels: apexLabels,
+                stroke: { width: 0 },
+                plotOptions: {
+                    pie: {
+                        donut: { size: type === 'donut' ? '65%' : '0%' },
+                    },
+                },
+            };
+        }
+
+        return {
+            ...base,
+            stroke: {
+                curve: 'smooth',
+                width: type === 'line' ? 2 : type === 'area' ? 2 : 0,
+            },
+            fill:
+                type === 'area'
+                    ? {
+                          type: 'gradient',
+                          gradient: {
+                              shadeIntensity: 1,
+                              opacityFrom: 0.4,
+                              opacityTo: 0.05,
+                              stops: [0, 100],
+                          },
+                      }
+                    : { opacity: 1 },
+            plotOptions: {
+                bar: {
+                    horizontal,
+                    borderRadius: 4,
+                    columnWidth: '65%',
+                },
+            },
+            grid: {
+                borderColor: 'var(--color-border-subtle)',
+                strokeDashArray: 3,
+                padding: { left: 8, right: 8 },
+            },
+            xaxis: {
+                categories: apexLabels,
+                axisBorder: { show: false },
+                axisTicks: { color: 'var(--color-border-subtle)' },
+                labels: {
+                    style: {
+                        colors: 'var(--color-text-subtle)',
+                        fontSize: '11px',
+                    },
+                },
+            },
+            yaxis: {
+                labels: {
+                    style: {
+                        colors: 'var(--color-text-subtle)',
+                        fontSize: '11px',
+                    },
+                    formatter: (v: number) =>
+                        new Intl.NumberFormat().format(Math.round(v)),
+                },
+            },
+        };
+    }, [type, resolvedColors, apexLabels, isPie, showLegend, horizontal]);
+
+    return (
+        <div className="min-h-[200px]">
+            <ReactApexChart
+                type={type}
+                options={options}
+                series={apexSeries as never}
+                height={height}
+            />
+        </div>
+    );
+}

--- a/tests/Feature/Admin/DashboardTest.php
+++ b/tests/Feature/Admin/DashboardTest.php
@@ -13,7 +13,19 @@ it('renders the admin dashboard for verified users', function (): void {
     $this->actingAs($user)
         ->get('/dashboard')
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page->component('Dashboard/Index'));
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Dashboard/Index')
+            ->has('totals')
+            ->has('packages')
+            ->has('packagist')
+            ->has('npm')
+            ->has('analytics')
+            ->has('search_console')
+            ->has('registry_breakdown')
+            ->has('status_breakdown')
+            ->has('top_documented')
+            ->has('recent_imports')
+            ->has('docs_distribution'));
 });
 
 it('redirects guests to login', function (): void {
@@ -26,4 +38,34 @@ it('redirects unverified users to email verification', function (): void {
     $this->actingAs($user)
         ->get('/dashboard')
         ->assertRedirect(route('verification.notice'));
+});
+
+it('withholds analytics-scoped payload from non-admin editors', function (): void {
+    $editor = User::factory()->editor()->create(['email_verified_at' => now()]);
+
+    $this->actingAs($editor)
+        ->get('/dashboard')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Dashboard/Index')
+            ->where('can_view_analytics', false)
+            ->where('analytics', null)
+            ->where('search_console', null)
+            ->where('totals.downloads', 0)
+            ->where('totals.monthly_downloads', 0)
+            ->where('totals.stars', 0)
+            ->where('packagist.is_configured', false)
+            ->where('npm.is_configured', false));
+});
+
+it('exposes analytics-scoped payload to admins', function (): void {
+    $admin = User::factory()->admin()->create(['email_verified_at' => now()]);
+
+    $this->actingAs($admin)
+        ->get('/dashboard')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Dashboard/Index')
+            ->where('can_view_analytics', true)
+            ->has('analytics'));
 });


### PR DESCRIPTION
## Summary

- Rebuilds `/dashboard` on the Inertia/React admin with gradient-bordered panels, ApexCharts bar/donut/area, and sparkline stat tiles — replaces the placeholder card with a live snapshot of packages, docs coverage, downloads, and site traffic.
- Analytics widget follows the site-wide first-party / Google Analytics toggle by injecting the container-bound `AnalyticsQuery` (`DashboardDataSourceManager`). Search Console panel drops out of the layout entirely when it isn't configured.
- Registry downloads, first-party/GA traffic, and Search Console data are gated behind `view-analytics`. The `/dashboard` route itself is only `auth+verified`, so verified editors would otherwise see data the gate was written to hide — the controller zeroes/nulls those props for non-admins and the frontend hides the corresponding tiles, charts, and panels.
- Chart wrapper lives locally (`resources/js/pages/Dashboard/components/DashChart.tsx`); `@artisanpack-ui/react/chart`'s pre-built ESM trips CJS/ESM default-interop for `react-apexcharts` under Vite and renders as a blank page.

## Test plan

- [x] `php artisan test tests/Feature/Admin/DashboardTest.php` — added editor-vs-admin coverage asserting analytics/download props are withheld for non-admins.
- [x] `vendor/bin/pint --dirty`
- [x] `npm run types`
- [x] `npm run build`
- [ ] Load `/dashboard` as an admin: all six rows render, source-switching toggle in Settings flips the "Site analytics" description label between first-party and Google Analytics.
- [ ] Load `/dashboard` as an editor: no download tiles, no downloads chart, no Packagist/NPM sidebar, no analytics/search-console panels; packages table + registry mix + status donut + docs distribution + recent imports still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)