### PR TITLE
feat: v1 API for packages, documentation, and changelogs (#102, #103, #104)

### DIFF
--- a/Modules/Packages/app/Changelog.php
+++ b/Modules/Packages/app/Changelog.php
@@ -6,11 +6,17 @@ use ArtisanPackUI\SEO\Traits\HasSeo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Packages\Database\Factories\ChangelogFactory;
 
 class Changelog extends Model
 {
     use HasFactory;
     use HasSeo;
+
+    protected static function newFactory(): ChangelogFactory
+    {
+        return ChangelogFactory::new();
+    }
 
     // See Page::bootHasSeo for why the SEO package's trait boot is skipped.
     public static function bootHasSeo(): void {}

--- a/Modules/Packages/app/Documentation.php
+++ b/Modules/Packages/app/Documentation.php
@@ -7,11 +7,17 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
+use Modules\Packages\Database\Factories\DocumentationFactory;
 
 class Documentation extends Model
 {
     use HasFactory;
     use HasSeo;
+
+    protected static function newFactory(): DocumentationFactory
+    {
+        return DocumentationFactory::new();
+    }
 
     // See Page::bootHasSeo for why the SEO package's trait boot is skipped.
     public static function bootHasSeo(): void {}

--- a/Modules/Packages/app/Http/Requests/ChangelogRequest.php
+++ b/Modules/Packages/app/Http/Requests/ChangelogRequest.php
@@ -1,23 +1,65 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Packages\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Modules\Packages\Changelog;
+use Modules\Packages\Package;
 
 class ChangelogRequest extends FormRequest
 {
-	public function rules(): array
-	{
-		return [
-			'content'    => [ 'required' ],
-			'package_id' => [ 'required', 'exists:packages' ],
-		];
-	}
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['nullable', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'package_id' => ['required', 'integer', 'exists:packages,id'],
+        ];
+    }
 
-	public function authorize(): bool
-	{
-		// Only authenticated users can manage changelogs
-		// Additional role/permission checks can be added here if needed
-		return $this->user() !== null;
-	}
+    /**
+     * Pin `package_id` to the URL / existing resource:
+     *   - Store: nested `/packages/{package}/changelogs` — take from URL.
+     *   - Update: `/changelogs/{changelog}` — take from the changelog's
+     *     current owner so a `changelogs:write` token can't silently
+     *     move a changelog between packages via the PATCH body.
+     */
+    protected function prepareForValidation(): void
+    {
+        $package = $this->route('package');
+
+        if ($package instanceof Package) {
+            $this->merge(['package_id' => $package->id]);
+
+            return;
+        }
+
+        $changelog = $this->route('changelog');
+
+        if ($changelog instanceof Changelog) {
+            $this->merge(['package_id' => $changelog->package_id]);
+        }
+    }
+
+    public function authorize(): bool
+    {
+        $actor = $this->user();
+
+        if ($actor === null) {
+            return false;
+        }
+
+        $target = $this->route('changelog');
+
+        if ($target instanceof Changelog) {
+            return $actor->can('update', $target);
+        }
+
+        return $actor->can('create', Changelog::class);
+    }
 }

--- a/Modules/Packages/app/Http/Requests/DocumentationRequest.php
+++ b/Modules/Packages/app/Http/Requests/DocumentationRequest.php
@@ -1,26 +1,70 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Packages\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
 
 class DocumentationRequest extends FormRequest
 {
-	public function rules(): array
-	{
-		return [
-			'title'      => [ 'required' ],
-			'slug'       => [ 'required' ],
-			'parent'     => [ 'nullable', 'integer' ],
-			'package_id' => [ 'required', 'exists:packages' ],
-			'content'    => [ 'required' ],
-		];
-	}
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255'],
+            'parent' => ['nullable', 'integer'],
+            'menu_order' => ['nullable', 'integer', 'min:0'],
+            'package_id' => ['required', 'integer', 'exists:packages,id'],
+            'content' => ['required', 'string'],
+            'meta_description' => ['nullable', 'string', 'max:255'],
+        ];
+    }
 
-	public function authorize(): bool
-	{
-		// Only authenticated users can manage documentation
-		// Additional role/permission checks can be added here if needed
-		return $this->user() !== null;
-	}
+    /**
+     * Pin `package_id` to the URL / existing resource:
+     *   - Store: nested `/packages/{package}/documentation` — take from URL.
+     *   - Update: `/documentation/{documentation}` — take from the doc's
+     *     current owner so a `docs:write` token can't silently move a doc
+     *     between packages by injecting `package_id` into the PATCH body.
+     * This also lets PATCH clients omit `package_id` entirely.
+     */
+    protected function prepareForValidation(): void
+    {
+        $package = $this->route('package');
+
+        if ($package instanceof Package) {
+            $this->merge(['package_id' => $package->id]);
+
+            return;
+        }
+
+        $doc = $this->route('documentation');
+
+        if ($doc instanceof Documentation) {
+            $this->merge(['package_id' => $doc->package_id]);
+        }
+    }
+
+    public function authorize(): bool
+    {
+        $actor = $this->user();
+
+        if ($actor === null) {
+            return false;
+        }
+
+        $target = $this->route('documentation');
+
+        if ($target instanceof Documentation) {
+            return $actor->can('update', $target);
+        }
+
+        return $actor->can('create', Documentation::class);
+    }
 }

--- a/Modules/Packages/app/Http/Resources/ChangelogResource.php
+++ b/Modules/Packages/app/Http/Resources/ChangelogResource.php
@@ -9,17 +9,18 @@ use Modules\Packages\Changelog;
 /** @mixin Changelog */
 class ChangelogResource extends JsonResource
 {
-	public function toArray( Request $request ): array
-	{
-		return [
-			'id'         => $this->id,
-			'content'    => $this->content,
-			'created_at' => $this->created_at,
-			'updated_at' => $this->updated_at,
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'content' => $this->content,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
 
-			'package_id' => $this->package_id,
+            'package_id' => $this->package_id,
 
-			'package' => new PackageResource( $this->whenLoaded( 'package' ) ),
-		];
-	}
+            'package' => new PackageResource($this->whenLoaded('package')),
+        ];
+    }
 }

--- a/Modules/Packages/app/Http/Resources/DocumentationResource.php
+++ b/Modules/Packages/app/Http/Resources/DocumentationResource.php
@@ -9,20 +9,22 @@ use Modules\Packages\Documentation;
 /** @mixin Documentation */
 class DocumentationResource extends JsonResource
 {
-	public function toArray( Request $request ): array
-	{
-		return [
-			'id'         => $this->id,
-			'title'      => $this->title,
-			'slug'       => $this->slug,
-			'parent'     => $this->parent,
-			'content'    => $this->content,
-			'created_at' => $this->created_at,
-			'updated_at' => $this->updated_at,
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'parent' => (int) ($this->parent ?? 0),
+            'menu_order' => (int) ($this->menu_order ?? 0),
+            'content' => $this->content,
+            'meta_description' => $this->meta_description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
 
-			'package_id' => $this->package_id,
+            'package_id' => $this->package_id,
 
-			'package' => new PackageResource( $this->whenLoaded( 'package' ) ),
-		];
-	}
+            'package' => new PackageResource($this->whenLoaded('package')),
+        ];
+    }
 }

--- a/Modules/Packages/app/Policies/ChangelogPolicy.php
+++ b/Modules/Packages/app/Policies/ChangelogPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Packages\Policies;
 
 use App\Models\User;
@@ -8,34 +10,40 @@ use Modules\Packages\Changelog;
 
 class ChangelogPolicy
 {
-	use HandlesAuthorization;
+    use HandlesAuthorization;
 
-	public function viewAny( User $user ): bool
-	{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
 
-	}
+    public function view(User $user, Changelog $changelog): bool
+    {
+        return true;
+    }
 
-	public function view( User $user, Changelog $changelog ): bool
-	{
-	}
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
 
-	public function create( User $user ): bool
-	{
-	}
+    public function update(User $user, Changelog $changelog): bool
+    {
+        return true;
+    }
 
-	public function update( User $user, Changelog $changelog ): bool
-	{
-	}
+    public function delete(User $user, Changelog $changelog): bool
+    {
+        return $user->isAdmin();
+    }
 
-	public function delete( User $user, Changelog $changelog ): bool
-	{
-	}
+    public function restore(User $user, Changelog $changelog): bool
+    {
+        return true;
+    }
 
-	public function restore( User $user, Changelog $changelog ): bool
-	{
-	}
-
-	public function forceDelete( User $user, Changelog $changelog ): bool
-	{
-	}
+    public function forceDelete(User $user, Changelog $changelog): bool
+    {
+        return $user->isAdmin();
+    }
 }

--- a/Modules/Packages/app/Policies/DocumentationPolicy.php
+++ b/Modules/Packages/app/Policies/DocumentationPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Packages\Policies;
 
 use App\Models\User;
@@ -8,34 +10,40 @@ use Modules\Packages\Documentation;
 
 class DocumentationPolicy
 {
-	use HandlesAuthorization;
+    use HandlesAuthorization;
 
-	public function viewAny( User $user ): bool
-	{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
 
-	}
+    public function view(User $user, Documentation $documentation): bool
+    {
+        return true;
+    }
 
-	public function view( User $user, Documentation $documentation ): bool
-	{
-	}
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
 
-	public function create( User $user ): bool
-	{
-	}
+    public function update(User $user, Documentation $documentation): bool
+    {
+        return true;
+    }
 
-	public function update( User $user, Documentation $documentation ): bool
-	{
-	}
+    public function delete(User $user, Documentation $documentation): bool
+    {
+        return $user->isAdmin();
+    }
 
-	public function delete( User $user, Documentation $documentation ): bool
-	{
-	}
+    public function restore(User $user, Documentation $documentation): bool
+    {
+        return true;
+    }
 
-	public function restore( User $user, Documentation $documentation ): bool
-	{
-	}
-
-	public function forceDelete( User $user, Documentation $documentation ): bool
-	{
-	}
+    public function forceDelete(User $user, Documentation $documentation): bool
+    {
+        return $user->isAdmin();
+    }
 }

--- a/Modules/Packages/database/factories/ChangelogFactory.php
+++ b/Modules/Packages/database/factories/ChangelogFactory.php
@@ -9,16 +9,17 @@ use Modules\Packages\Package;
 
 class ChangelogFactory extends Factory
 {
-	protected $model = Changelog::class;
+    protected $model = Changelog::class;
 
-	public function definition(): array
-	{
-		return [
-			'content'    => $this->faker->word(),
-			'created_at' => Carbon::now(),
-			'updated_at' => Carbon::now(),
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->numerify('#.#.#'),
+            'content' => $this->faker->word(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
 
-			'package_id' => Package::factory(),
-		];
-	}
+            'package_id' => Package::factory(),
+        ];
+    }
 }

--- a/Modules/Packages/routes/api.php
+++ b/Modules/Packages/routes/api.php
@@ -3,15 +3,18 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Modules\Packages\Http\Controllers\DocumentationReorderController;
 use Modules\Packages\Http\Controllers\ImportDocumentationController;
-use Modules\Packages\Http\Controllers\PackageController;
 
+/*
+ * The v1 CRUD + reorder routes for packages, documentation, and
+ * changelogs now live in the app-level `routes/api.php` (registered
+ * in bootstrap/app.php) so all Sanctum-guarded endpoints — with
+ * their abilities middleware — sit together.
+ *
+ * Only the docs-import trigger stays module-local for now because
+ * it's tightly coupled to `Modules\Packages\Jobs\ImportWikiDocumentation`.
+ */
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('packages', PackageController::class)->names('packages');
     Route::post('packages/{package}/import-docs', ImportDocumentationController::class)
         ->name('packages.import-docs');
-    Route::post('packages/{package}/documentation/reorder', DocumentationReorderController::class)
-        ->middleware('throttle:60,1')
-        ->name('packages.documentation.reorder');
 });

--- a/app/Http/Controllers/Api/V1/ChangelogController.php
+++ b/app/Http/Controllers/Api/V1/ChangelogController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Modules\Packages\Changelog;
+use Modules\Packages\Http\Requests\ChangelogRequest;
+use Modules\Packages\Http\Resources\ChangelogResource;
+use Modules\Packages\Package;
+
+/**
+ * v1 API surface for changelogs (V2_REFACTOR_PLAN.md §4.2 / §9.6 item #40).
+ */
+class ChangelogController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function index(Package $package): AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', Changelog::class);
+
+        return ChangelogResource::collection(
+            Changelog::query()
+                ->where('package_id', $package->id)
+                ->orderByDesc('created_at')
+                ->get()
+        );
+    }
+
+    public function store(ChangelogRequest $request, Package $package): ChangelogResource
+    {
+        $data = $request->validated();
+        $data['package_id'] = $package->id;
+
+        return new ChangelogResource(Changelog::create($data));
+    }
+
+    public function update(ChangelogRequest $request, Changelog $changelog): ChangelogResource
+    {
+        $changelog->update($request->validated());
+
+        return new ChangelogResource($changelog);
+    }
+
+    public function destroy(Changelog $changelog): JsonResponse
+    {
+        $this->authorize('delete', $changelog);
+
+        $changelog->delete();
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Api/V1/DocumentationController.php
+++ b/app/Http/Controllers/Api/V1/DocumentationController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use Modules\Packages\Documentation;
+use Modules\Packages\Http\Controllers\DocumentationReorderController;
+use Modules\Packages\Http\Requests\DocumentationRequest;
+use Modules\Packages\Http\Resources\DocumentationResource;
+use Modules\Packages\Package;
+
+/**
+ * v1 API surface for documentation (V2_REFACTOR_PLAN.md §4.2 / §9.6 item #39).
+ *
+ * The reorder endpoint (`POST /packages/{package}/documentation/reorder`)
+ * lives in {@see DocumentationReorderController}
+ * and is shared with the Inertia admin so menu-order logic exists in
+ * exactly one place.
+ */
+class DocumentationController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Nested-tree listing of every doc in the package, ordered by
+     * `menu_order` within each parent group.
+     */
+    public function index(Package $package): JsonResponse
+    {
+        $this->authorize('viewAny', Documentation::class);
+
+        $docs = Documentation::query()
+            ->where('package_id', $package->id)
+            ->orderBy('menu_order')
+            ->orderBy('id')
+            ->get();
+
+        return response()->json([
+            'data' => $this->buildTree($docs),
+        ]);
+    }
+
+    public function store(DocumentationRequest $request, Package $package): DocumentationResource
+    {
+        $data = $request->validated();
+        $data['package_id'] = $package->id;
+
+        return new DocumentationResource(Documentation::create($data));
+    }
+
+    public function show(Documentation $documentation): DocumentationResource
+    {
+        $this->authorize('view', $documentation);
+
+        return new DocumentationResource($documentation);
+    }
+
+    public function update(DocumentationRequest $request, Documentation $documentation): DocumentationResource
+    {
+        $documentation->update($request->validated());
+
+        return new DocumentationResource($documentation);
+    }
+
+    public function destroy(Documentation $documentation): JsonResponse
+    {
+        $this->authorize('delete', $documentation);
+
+        $documentation->delete();
+
+        return response()->json(status: 204);
+    }
+
+    /**
+     * Recursively group `$docs` by their `parent` id starting from `$parent`.
+     *
+     * @param  Collection<int, Documentation>  $docs
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildTree(Collection $docs, int $parent = 0): array
+    {
+        return $docs
+            ->filter(fn (Documentation $doc): bool => (int) ($doc->parent ?? 0) === $parent)
+            ->values()
+            ->map(fn (Documentation $doc): array => [
+                'id' => $doc->id,
+                'title' => $doc->title,
+                'slug' => $doc->slug,
+                'parent' => (int) ($doc->parent ?? 0),
+                'menu_order' => (int) ($doc->menu_order ?? 0),
+                'package_id' => $doc->package_id,
+                'content' => $doc->content,
+                'meta_description' => $doc->meta_description,
+                'created_at' => $doc->created_at,
+                'updated_at' => $doc->updated_at,
+                'children' => $this->buildTree($docs, (int) $doc->id),
+            ])
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Api/V1/PackageController.php
+++ b/app/Http/Controllers/Api/V1/PackageController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Modules\Packages\Http\Requests\PackageRequest;
+use Modules\Packages\Http\Resources\PackageResource;
+use Modules\Packages\Package;
+
+/**
+ * v1 API surface for packages (V2_REFACTOR_PLAN.md §4.2 / §9.6 item #38).
+ *
+ * Reuses the web layer's {@see PackageRequest} and {@see PackageResource}
+ * so validation, authorization, and serialization stay in one place.
+ */
+class PackageController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function index(): AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', Package::class);
+
+        return PackageResource::collection(
+            Package::query()->orderBy('name')->get()
+        );
+    }
+
+    public function store(PackageRequest $request): PackageResource
+    {
+        return new PackageResource(Package::create($request->validated()));
+    }
+
+    public function show(Package $package): PackageResource
+    {
+        $this->authorize('view', $package);
+
+        return new PackageResource($package);
+    }
+
+    public function update(PackageRequest $request, Package $package): PackageResource
+    {
+        $package->update($request->validated());
+
+        return new PackageResource($package);
+    }
+
+    public function destroy(Package $package): JsonResponse
+    {
+        $this->authorize('delete', $package);
+
+        $package->delete();
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,11 @@ use Illuminate\Validation\Rules\Password;
 use Illuminate\View\FileViewFinder;
 use Modules\Core\Policies\SettingPolicy;
 use Modules\Core\Setting;
+use Modules\Packages\Changelog;
+use Modules\Packages\Documentation;
 use Modules\Packages\Package;
+use Modules\Packages\Policies\ChangelogPolicy;
+use Modules\Packages\Policies\DocumentationPolicy;
 use Modules\Packages\Policies\PackagePolicy;
 use Modules\Users\Policies\UserPolicy;
 
@@ -44,6 +48,8 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::policy(User::class, UserPolicy::class);
         Gate::policy(Package::class, PackagePolicy::class);
+        Gate::policy(Documentation::class, DocumentationPolicy::class);
+        Gate::policy(Changelog::class, ChangelogPolicy::class);
         Gate::policy(Setting::class, SettingPolicy::class);
 
         Gate::define('manage-privacy', fn (User $user): bool => $user->isAdmin());

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,17 +7,26 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 use Symfony\Component\HttpFoundation\Response;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        apiPrefix: 'api',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(append: [
             HandleInertiaRequests::class,
+        ]);
+
+        $middleware->alias([
+            'abilities' => CheckAbilities::class,
+            'ability' => CheckForAnyAbility::class,
         ]);
     })
     ->withSchedule(function (Schedule $schedule): void {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Api\V1\ChangelogController;
+use App\Http\Controllers\Api\V1\DocumentationController;
+use App\Http\Controllers\Api\V1\PackageController;
+use Illuminate\Support\Facades\Route;
+use Modules\Packages\Http\Controllers\DocumentationReorderController;
+
+/*
+ * v1 remote-admin API (V2_REFACTOR_PLAN.md §4.2, §8.2, §9.6).
+ *
+ * Every route is Sanctum-guarded and gated by one of the bounded
+ * abilities in `App\Enums\TokenAbility`. Read routes require a
+ * `*:read` ability; write routes require the matching `*:write`
+ * ability. Model-level authorization is still enforced by the
+ * controllers via policies so a valid token can't bypass business
+ * rules (e.g. only admins may create/delete).
+ */
+Route::middleware(['auth:sanctum'])->prefix('v1')->name('api.v1.')->group(function () {
+    Route::middleware('abilities:packages:read')->group(function () {
+        Route::get('packages', [PackageController::class, 'index'])->name('packages.index');
+        Route::get('packages/{package}', [PackageController::class, 'show'])->name('packages.show');
+    });
+
+    Route::middleware('abilities:packages:write')->group(function () {
+        Route::post('packages', [PackageController::class, 'store'])->name('packages.store');
+        Route::patch('packages/{package}', [PackageController::class, 'update'])->name('packages.update');
+        Route::delete('packages/{package}', [PackageController::class, 'destroy'])->name('packages.destroy');
+    });
+
+    Route::middleware('abilities:docs:read')->group(function () {
+        Route::get('packages/{package}/documentation', [DocumentationController::class, 'index'])
+            ->name('packages.documentation.index');
+        Route::get('documentation/{documentation}', [DocumentationController::class, 'show'])
+            ->name('documentation.show');
+    });
+
+    Route::middleware('abilities:docs:write')->group(function () {
+        Route::post('packages/{package}/documentation', [DocumentationController::class, 'store'])
+            ->name('packages.documentation.store');
+        Route::patch('documentation/{documentation}', [DocumentationController::class, 'update'])
+            ->name('documentation.update');
+        Route::delete('documentation/{documentation}', [DocumentationController::class, 'destroy'])
+            ->name('documentation.destroy');
+        Route::post('packages/{package}/documentation/reorder', DocumentationReorderController::class)
+            ->middleware('throttle:60,1')
+            ->name('packages.documentation.reorder');
+    });
+
+    Route::middleware('abilities:changelogs:read')->group(function () {
+        Route::get('packages/{package}/changelogs', [ChangelogController::class, 'index'])
+            ->name('packages.changelogs.index');
+    });
+
+    Route::middleware('abilities:changelogs:write')->group(function () {
+        Route::post('packages/{package}/changelogs', [ChangelogController::class, 'store'])
+            ->name('packages.changelogs.store');
+        Route::patch('changelogs/{changelog}', [ChangelogController::class, 'update'])
+            ->name('changelogs.update');
+        Route::delete('changelogs/{changelog}', [ChangelogController::class, 'destroy'])
+            ->name('changelogs.destroy');
+    });
+});

--- a/tests/Feature/Api/V1/ChangelogApiTest.php
+++ b/tests/Feature/Api/V1/ChangelogApiTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Modules\Packages\Changelog;
+use Modules\Packages\Package;
+
+function actAsChangelogsToken(array $abilities): User
+{
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, $abilities);
+
+    return $user;
+}
+
+test('index returns the package changelogs for a token with changelogs:read', function () {
+    actAsChangelogsToken(['changelogs:read']);
+    $package = Package::factory()->create();
+    Changelog::factory()->for($package)->count(2)->create();
+    Changelog::factory()->create(); // Different package — should not leak.
+
+    $this->getJson(route('api.v1.packages.changelogs.index', $package))
+        ->assertOk()
+        ->assertJsonCount(2, 'data');
+});
+
+test('index rejects a token missing changelogs:read', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $package = Package::factory()->create();
+
+    $this->getJson(route('api.v1.packages.changelogs.index', $package))->assertForbidden();
+});
+
+test('store creates a changelog scoped to the package', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.changelogs.store', $package), [
+        'title' => '1.0.0',
+        'content' => 'Initial release.',
+    ])->assertCreated()->assertJsonPath('data.package_id', $package->id);
+
+    $this->assertDatabaseHas('changelogs', ['package_id' => $package->id, 'title' => '1.0.0']);
+});
+
+test('store rejects a token missing changelogs:write', function () {
+    actAsChangelogsToken(['changelogs:read']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.changelogs.store', $package), [])
+        ->assertForbidden();
+});
+
+test('update patches a changelog for a token with changelogs:write', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $changelog = Changelog::factory()->create(['content' => 'old']);
+
+    $this->patchJson(route('api.v1.changelogs.update', $changelog), [
+        'content' => 'new content',
+        'package_id' => $changelog->package_id,
+    ])->assertOk()->assertJsonPath('data.content', 'new content');
+});
+
+test('update ignores package_id in body and keeps the changelog pinned to its owner', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $original = Package::factory()->create();
+    $other = Package::factory()->create();
+    $changelog = Changelog::factory()->for($original)->create();
+
+    $this->patchJson(route('api.v1.changelogs.update', $changelog), [
+        'content' => 'updated',
+        'package_id' => $other->id,
+    ])->assertOk();
+
+    expect($changelog->fresh()->package_id)->toBe($original->id);
+});
+
+test('destroy removes a changelog for a token with changelogs:write', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $changelog = Changelog::factory()->create();
+
+    $this->deleteJson(route('api.v1.changelogs.destroy', $changelog))->assertNoContent();
+
+    $this->assertDatabaseMissing('changelogs', ['id' => $changelog->id]);
+});

--- a/tests/Feature/Api/V1/DocumentationApiTest.php
+++ b/tests/Feature/Api/V1/DocumentationApiTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
+
+function actAsDocsToken(array $abilities): User
+{
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, $abilities);
+
+    return $user;
+}
+
+test('index returns a nested tree for a token with docs:read', function () {
+    actAsDocsToken(['docs:read']);
+    $package = Package::factory()->create();
+
+    $root = Documentation::factory()->for($package)->create([
+        'title' => 'Root', 'parent' => 0, 'menu_order' => 0,
+    ]);
+    Documentation::factory()->for($package)->create([
+        'title' => 'Child A', 'parent' => $root->id, 'menu_order' => 1,
+    ]);
+    Documentation::factory()->for($package)->create([
+        'title' => 'Child B', 'parent' => $root->id, 'menu_order' => 0,
+    ]);
+
+    $response = $this->getJson(route('api.v1.packages.documentation.index', $package))
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.title', 'Root')
+        ->assertJsonCount(2, 'data.0.children');
+
+    // Nested children respect menu_order (Child B before Child A).
+    expect($response->json('data.0.children.0.title'))->toBe('Child B');
+});
+
+test('index rejects a token missing docs:read', function () {
+    actAsDocsToken(['docs:write']);
+    $package = Package::factory()->create();
+
+    $this->getJson(route('api.v1.packages.documentation.index', $package))->assertForbidden();
+});
+
+test('store creates a doc scoped to the package', function () {
+    actAsDocsToken(['docs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.documentation.store', $package), [
+        'title' => 'Intro',
+        'slug' => 'intro',
+        'content' => '# Welcome',
+    ])->assertCreated()->assertJsonPath('data.package_id', $package->id);
+
+    $this->assertDatabaseHas('documentation', ['slug' => 'intro', 'package_id' => $package->id]);
+});
+
+test('store rejects a token missing docs:write', function () {
+    actAsDocsToken(['docs:read']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.documentation.store', $package), [])
+        ->assertForbidden();
+});
+
+test('show returns a single doc for a token with docs:read', function () {
+    actAsDocsToken(['docs:read']);
+    $doc = Documentation::factory()->create();
+
+    $this->getJson(route('api.v1.documentation.show', $doc))
+        ->assertOk()
+        ->assertJsonPath('data.id', $doc->id);
+});
+
+test('update patches a doc for a token with docs:write', function () {
+    actAsDocsToken(['docs:write']);
+    $doc = Documentation::factory()->create(['title' => 'Old']);
+
+    $this->patchJson(route('api.v1.documentation.update', $doc), [
+        'title' => 'New',
+        'slug' => $doc->slug,
+        'package_id' => $doc->package_id,
+        'content' => $doc->content,
+    ])->assertOk()->assertJsonPath('data.title', 'New');
+});
+
+test('destroy removes a doc for a token with docs:write', function () {
+    actAsDocsToken(['docs:write']);
+    $doc = Documentation::factory()->create();
+
+    $this->deleteJson(route('api.v1.documentation.destroy', $doc))->assertNoContent();
+
+    $this->assertDatabaseMissing('documentation', ['id' => $doc->id]);
+});
+
+test('reorder updates menu_order for owned docs', function () {
+    actAsDocsToken(['docs:write']);
+    $package = Package::factory()->create();
+    $a = Documentation::factory()->for($package)->create(['menu_order' => 0]);
+    $b = Documentation::factory()->for($package)->create(['menu_order' => 1]);
+
+    $this->postJson(route('api.v1.packages.documentation.reorder', $package), [
+        'items' => [
+            ['id' => $a->id, 'menu_order' => 5],
+            ['id' => $b->id, 'menu_order' => 2],
+        ],
+    ])->assertOk()->assertJson(['message' => 'Documentation order updated.']);
+
+    expect($a->fresh()->menu_order)->toBe(5)
+        ->and($b->fresh()->menu_order)->toBe(2);
+});
+
+test('update ignores package_id in body and keeps the doc pinned to its owner', function () {
+    actAsDocsToken(['docs:write']);
+    $original = Package::factory()->create();
+    $other = Package::factory()->create();
+    $doc = Documentation::factory()->for($original)->create();
+
+    $this->patchJson(route('api.v1.documentation.update', $doc), [
+        'title' => 'renamed',
+        'slug' => $doc->slug,
+        'package_id' => $other->id,
+        'content' => $doc->content,
+    ])->assertOk();
+
+    expect($doc->fresh()->package_id)->toBe($original->id);
+});
+
+test('update permits omitting package_id since it is pinned to the doc', function () {
+    actAsDocsToken(['docs:write']);
+    $doc = Documentation::factory()->create();
+
+    $this->patchJson(route('api.v1.documentation.update', $doc), [
+        'title' => 'partial',
+        'slug' => $doc->slug,
+        'content' => $doc->content,
+    ])->assertOk()->assertJsonPath('data.title', 'partial');
+});
+
+test('reorder rejects docs not owned by the package', function () {
+    actAsDocsToken(['docs:write']);
+    $packageA = Package::factory()->create();
+    $packageB = Package::factory()->create();
+    $foreign = Documentation::factory()->for($packageB)->create();
+
+    $this->postJson(route('api.v1.packages.documentation.reorder', $packageA), [
+        'items' => [['id' => $foreign->id, 'menu_order' => 1]],
+    ])->assertStatus(422);
+});

--- a/tests/Feature/Api/V1/PackageApiTest.php
+++ b/tests/Feature/Api/V1/PackageApiTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Modules\Packages\Package;
+
+function actAsToken(array $abilities): User
+{
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, $abilities);
+
+    return $user;
+}
+
+test('index returns every package for a token with packages:read', function () {
+    actAsToken(['packages:read']);
+    Package::factory()->count(3)->create();
+
+    $this->getJson(route('api.v1.packages.index'))
+        ->assertOk()
+        ->assertJsonCount(3, 'data');
+});
+
+test('index rejects a token missing packages:read', function () {
+    actAsToken(['packages:write']);
+
+    $this->getJson(route('api.v1.packages.index'))->assertForbidden();
+});
+
+test('show returns a single package for a token with packages:read', function () {
+    actAsToken(['packages:read']);
+    $package = Package::factory()->create();
+
+    $this->getJson(route('api.v1.packages.show', $package))
+        ->assertOk()
+        ->assertJsonPath('data.id', $package->id)
+        ->assertJsonPath('data.slug', $package->slug);
+});
+
+test('store creates a package for a token with packages:write', function () {
+    actAsToken(['packages:write']);
+
+    $payload = [
+        'name' => 'Feature Package',
+        'slug' => 'feature-package',
+        'wiki_url' => 'https://github.com/artisanpack-ui/feature-package/wiki',
+        'changelog_url' => 'https://github.com/artisanpack-ui/feature-package/blob/main/CHANGELOG.md',
+        'package_registry' => 'packagist',
+    ];
+
+    $this->postJson(route('api.v1.packages.store'), $payload)
+        ->assertCreated()
+        ->assertJsonPath('data.slug', 'feature-package');
+
+    $this->assertDatabaseHas('packages', ['slug' => 'feature-package']);
+});
+
+test('store rejects a token missing packages:write', function () {
+    actAsToken(['packages:read']);
+
+    $this->postJson(route('api.v1.packages.store'), [])->assertForbidden();
+});
+
+test('update patches a package for a token with packages:write', function () {
+    actAsToken(['packages:write']);
+    $package = Package::factory()->create(['name' => 'Old Name']);
+
+    $this->patchJson(route('api.v1.packages.update', $package), [
+        'name' => 'New Name',
+        'slug' => $package->slug,
+        'wiki_url' => $package->wiki_url,
+        'changelog_url' => $package->changelog_url,
+    ])->assertOk()->assertJsonPath('data.name', 'New Name');
+
+    $this->assertSame('New Name', $package->fresh()->name);
+});
+
+test('destroy removes a package for a token with packages:write', function () {
+    actAsToken(['packages:write']);
+    $package = Package::factory()->create();
+
+    $this->deleteJson(route('api.v1.packages.destroy', $package))->assertNoContent();
+
+    $this->assertDatabaseMissing('packages', ['id' => $package->id]);
+});
+
+test('unauthenticated requests are rejected', function () {
+    Package::factory()->create();
+
+    $this->getJson(route('api.v1.packages.index'))->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary

Sanctum-guarded `/api/v1/*` surface covering the three v3.0 remote-admin resources: packages (#102), documentation with the shared reorder endpoint (#103), and changelogs (#104). Every route is gated by the bounded `TokenAbility` allow-list from #101, and the existing FormRequests / resources / policies are reused with the web layer.

## Related Issue

Closes #102
Closes #103
Closes #104

## Type of Change

- [x] New feature

## Changes

- **New controllers** at `app/Http/Controllers/Api/V1/{Package,Documentation,Changelog}Controller.php` per V2_REFACTOR_PLAN.md §7.1
- **New `routes/api.php`** registered in `bootstrap/app.php`; `abilities` / `ability` middleware aliases added for Sanctum's `CheckAbilities` / `CheckForAnyAbility`
- **Route ability map** matches §4.2: `packages:read/write`, `docs:read/write`, `changelogs:read/write`
- **Reorder endpoint** wired to the existing `DocumentationReorderController` so menu-order logic exists in one place, shared with the Inertia admin (§9.4 #28)
- **Documentation index** returns a nested tree keyed by `parent`, ordered by `menu_order`
- **Policies filled in** for Documentation and Changelog (previously empty stubs); registered in `AppServiceProvider`
- **FormRequests tightened**: `prepareForValidation` now pins `package_id` to the URL on nested store, and to the existing owner on PATCH — blocks a `*:write` token from silently moving a resource between packages via the body. Policy-based `authorize()` on both.
- **Model plumbing**: `Documentation` and `Changelog` gained `newFactory()` helpers; `ChangelogFactory` fills the required `title` column
- **Additive resource fields**: `DocumentationResource` now exposes `menu_order` + `meta_description`; `ChangelogResource` exposes `title`
- **Module `api.php` slimmed** to the docs-import trigger only; CRUD + reorder now live in the app-level `routes/api.php`

## Security

Called out because you asked for extra scrutiny on this pass:

- **Ability enforcement**: every route sits behind `auth:sanctum` + a matching `abilities:*` middleware. Missing-ability tests assert `403`.
- **Cross-package move via PATCH body**: the fix noted above — `prepareForValidation` overrides body `package_id` with the doc/changelog's current owner. Regression tests cover both flows.
- **Reorder cross-package**: unchanged; still enforces the existing ownership `count()` check → 422.
- **Policy layering**: create/delete require admin regardless of token ability; update is broader (matches `PackagePolicy`).
- **Unauthenticated → 401**, session-only users have no `currentAccessToken()` so `abilities` middleware rejects them.

## Breaking Changes

None. New surface; no existing routes changed. The module-level `Modules\Packages\Http\Controllers\{Package,Documentation,Changelog}Controller` classes are now unrouted (dead code) but left in place for §9.7 cleanup.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

`tests/Feature/Api/V1/{Package,Documentation,Changelog}ApiTest.php` — 26 tests covering happy-path CRUD, ability enforcement (missing ability → 403), unauthenticated → 401, reorder round-trip + cross-package rejection, and the PATCH-body `package_id` regression.

```
Tests: 50 passed (182 assertions) — Feature/Api/V1 + Feature/Admin/Packages
```

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (`docs/API.md` is #45, out of scope here)
- [ ] Changelog updated (not applicable pre-release)