### PR TITLE
feat: Sanctum PAT management UI and bootstrap command

### DIFF
--- a/app/Console/Commands/IssueTokenCommand.php
+++ b/app/Console/Commands/IssueTokenCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\TokenAbility;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class IssueTokenCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'artisanpack:issue-token
+        {--user= : The email address of the user to issue the token to}
+        {--name= : A human-readable name for the token}
+        {--ability=* : One or more abilities to grant (repeat --ability for each)}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Mint a Sanctum personal access token for a user and print it once.';
+
+    public function handle(): int
+    {
+        $user = $this->resolveUser();
+
+        if (! $user instanceof User) {
+            $this->error('No user found for the provided email.');
+
+            return self::FAILURE;
+        }
+
+        $name = $this->resolveName();
+
+        if ($name === '') {
+            $this->error('A token name is required.');
+
+            return self::FAILURE;
+        }
+
+        $abilities = $this->resolveAbilities();
+
+        if ($abilities === []) {
+            $this->error('At least one ability is required.');
+
+            return self::FAILURE;
+        }
+
+        $token = $user->createToken($name, $abilities)->plainTextToken;
+
+        $this->info('Token generated. Copy it now — it will not be shown again.');
+        $this->newLine();
+        $this->line($token);
+        $this->newLine();
+        $this->line('Issued to: '.$user->email);
+        $this->line('Name: '.$name);
+        $this->line('Abilities: '.implode(', ', $abilities));
+
+        return self::SUCCESS;
+    }
+
+    private function resolveUser(): ?User
+    {
+        $email = $this->option('user');
+
+        if (! is_string($email) || $email === '') {
+            $email = (string) text(
+                label: 'Which user should this token belong to?',
+                placeholder: 'admin@example.com',
+                required: true,
+                validate: fn (string $value): ?string => filter_var($value, FILTER_VALIDATE_EMAIL) === false
+                    ? 'Please enter a valid email address.'
+                    : null,
+            );
+        }
+
+        return User::query()->where('email', $email)->first();
+    }
+
+    private function resolveName(): string
+    {
+        $name = $this->option('name');
+
+        if (is_string($name) && $name !== '') {
+            return $name;
+        }
+
+        return (string) text(
+            label: 'Token name',
+            placeholder: 'artisanpackui.dev production',
+            required: true,
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveAbilities(): array
+    {
+        /** @var array<int, string> $provided */
+        $provided = (array) $this->option('ability');
+        $provided = array_values(array_filter($provided, fn ($value): bool => is_string($value) && $value !== ''));
+
+        if ($provided !== []) {
+            $invalid = array_values(array_filter($provided, fn (string $value): bool => ! TokenAbility::isAllowed($value)));
+
+            if ($invalid !== []) {
+                $this->error('Unknown ability: '.implode(', ', $invalid));
+                $this->line('Allowed abilities: '.implode(', ', TokenAbility::values()));
+
+                return [];
+            }
+
+            return array_values(array_unique($provided));
+        }
+
+        $mode = select(
+            label: 'How should abilities be assigned?',
+            options: [
+                'all' => 'Grant all abilities',
+                'choose' => 'Choose specific abilities',
+            ],
+            default: 'choose',
+        );
+
+        if ($mode === 'all') {
+            return TokenAbility::values();
+        }
+
+        /** @var array<int, string> $selected */
+        $selected = multiselect(
+            label: 'Which abilities should this token have?',
+            options: array_combine(
+                TokenAbility::values(),
+                array_map(fn (TokenAbility $ability): string => $ability->label(), TokenAbility::cases()),
+            ),
+            required: true,
+        );
+
+        return array_values($selected);
+    }
+}

--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Enums\TokenAbility;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ApiTokenController extends Controller
+{
+    /**
+     * Show the API tokens settings page.
+     */
+    public function show(Request $request): Response
+    {
+        $user = $request->user();
+
+        $tokens = $user->tokens()
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (PersonalAccessToken $token): array => [
+                'id' => $token->id,
+                'name' => $token->name,
+                'abilities' => array_values(array_filter(
+                    (array) $token->abilities,
+                    fn ($ability): bool => is_string($ability),
+                )),
+                'last_used_at' => optional($token->last_used_at)->toIso8601String(),
+                'created_at' => optional($token->created_at)->toIso8601String(),
+            ])
+            ->all();
+
+        return Inertia::render('Settings/ApiTokens', [
+            'tokens' => $tokens,
+            'availableAbilities' => TokenAbility::options(),
+            'newToken' => $request->session()->get('new_api_token'),
+            'status' => $request->session()->get('status'),
+        ]);
+    }
+
+    /**
+     * Issue a new personal access token for the current user.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'abilities' => ['required', 'array', 'min:1'],
+            'abilities.*' => ['string', Rule::in(TokenAbility::values())],
+        ]);
+
+        $abilities = array_values(array_unique($validated['abilities']));
+
+        $newToken = $request->user()->createToken($validated['name'], $abilities);
+
+        return back()
+            ->with('status', 'api-token-created')
+            ->with('new_api_token', [
+                'name' => $validated['name'],
+                'plain_text' => $newToken->plainTextToken,
+            ]);
+    }
+
+    /**
+     * Revoke one of the current user's tokens.
+     */
+    public function destroy(Request $request, int $token): RedirectResponse
+    {
+        $deleted = $request->user()->tokens()->whereKey($token)->delete();
+
+        if ($deleted === 0) {
+            abort(404);
+        }
+
+        return back()->with('status', 'api-token-revoked');
+    }
+}

--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -10,8 +10,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
-use Inertia\Response;
 use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\Response;
 
 class ApiTokenController extends Controller
 {
@@ -37,12 +37,19 @@ class ApiTokenController extends Controller
             ])
             ->all();
 
-        return Inertia::render('Settings/ApiTokens', [
+        $response = Inertia::render('Settings/ApiTokens', [
             'tokens' => $tokens,
             'availableAbilities' => TokenAbility::options(),
             'newToken' => $request->session()->get('new_api_token'),
             'status' => $request->session()->get('status'),
-        ]);
+        ])->toResponse($request);
+
+        // Prevent bfcache / disk cache / intermediate proxies from retaining
+        // the freshly issued plain-text token that is flashed into this view.
+        $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+        $response->headers->set('Pragma', 'no-cache');
+
+        return $response;
     }
 
     /**

--- a/resources/js/layouts/AdminLayout.tsx
+++ b/resources/js/layouts/AdminLayout.tsx
@@ -36,6 +36,7 @@ const ACCOUNT_LINKS: { label: string; href: string }[] = [
     { label: 'Password', href: '/dashboard/settings/password' },
     { label: 'Appearance', href: '/dashboard/settings/appearance' },
     { label: 'Two-Factor Auth', href: '/dashboard/settings/two-factor' },
+    { label: 'API Tokens', href: '/dashboard/settings/api-tokens' },
 ];
 
 function AccountMenu({ name }: { name: string }) {

--- a/resources/js/pages/Settings/ApiTokens.tsx
+++ b/resources/js/pages/Settings/ApiTokens.tsx
@@ -1,0 +1,234 @@
+import { Head, useForm, router } from '@inertiajs/react';
+import { Button, Checkbox, Input } from '@artisanpack-ui/react/form';
+import { Card } from '@artisanpack-ui/react/layout';
+import { Alert } from '@artisanpack-ui/react/feedback';
+import { type FormEventHandler } from 'react';
+
+import { AdminLayout } from '../../layouts/AdminLayout';
+
+interface TokenSummary {
+    id: number;
+    name: string;
+    abilities: string[];
+    last_used_at: string | null;
+    created_at: string | null;
+}
+
+interface AbilityOption {
+    value: string;
+    label: string;
+}
+
+interface NewToken {
+    name: string;
+    plain_text: string;
+}
+
+interface ApiTokensProps {
+    tokens: TokenSummary[];
+    availableAbilities: AbilityOption[];
+    newToken: NewToken | null;
+    status: string | null;
+}
+
+type CreateForm = {
+    name: string;
+    abilities: string[];
+};
+
+const STATUS_MESSAGES: Record<string, string> = {
+    'api-token-created': 'Token generated. Copy it now — it will not be shown again.',
+    'api-token-revoked': 'Token revoked.',
+};
+
+function formatDate(value: string | null): string {
+    if (!value) {
+        return '—';
+    }
+
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
+}
+
+export default function ApiTokens({ tokens, availableAbilities, newToken, status }: ApiTokensProps) {
+    const { data, setData, post, processing, errors, reset } = useForm<CreateForm>({
+        name: '',
+        abilities: [],
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+        post('/dashboard/settings/api-tokens', {
+            preserveScroll: true,
+            onSuccess: () => reset('name', 'abilities'),
+        });
+    };
+
+    const toggleAbility = (value: string, checked: boolean) => {
+        if (checked) {
+            setData('abilities', Array.from(new Set([...data.abilities, value])));
+        } else {
+            setData('abilities', data.abilities.filter((ability) => ability !== value));
+        }
+    };
+
+    const revoke = (token: TokenSummary) => {
+        if (!window.confirm(`Revoke the "${token.name}" token? This cannot be undone.`)) {
+            return;
+        }
+
+        router.delete(`/dashboard/settings/api-tokens/${token.id}`, {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <AdminLayout title="API tokens">
+            <Head title="API tokens" />
+
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+                <header>
+                    <p className="text-small text-text-muted">
+                        Personal access tokens let external clients — like{' '}
+                        <code>artisanpackui.dev</code> — call this site's API on your
+                        behalf. Grant only the abilities the client needs and rotate
+                        tokens every 90 days.
+                    </p>
+                </header>
+
+                {status && STATUS_MESSAGES[status] ? (
+                    <Alert color="success">{STATUS_MESSAGES[status]}</Alert>
+                ) : null}
+
+                {newToken ? (
+                    <Alert color="warning">
+                        <div className="flex flex-col gap-2">
+                            <p className="font-semibold">
+                                New token for "{newToken.name}"
+                            </p>
+                            <p className="text-small">
+                                Copy this token now — it will not be shown again.
+                            </p>
+                            <code
+                                className="block break-all rounded-box bg-surface p-3 font-mono text-small"
+                                data-testid="new-api-token"
+                            >
+                                {newToken.plain_text}
+                            </code>
+                        </div>
+                    </Alert>
+                ) : null}
+
+                <Card>
+                    <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
+                        <h2 className="text-medium font-semibold">Issue a new token</h2>
+
+                        <Input
+                            id="name"
+                            name="name"
+                            type="text"
+                            label="Token name"
+                            placeholder="e.g. artisanpackui.dev production"
+                            required
+                            value={data.name}
+                            onChange={(event) => setData('name', event.target.value)}
+                            error={errors.name}
+                        />
+
+                        <fieldset className="flex flex-col gap-3">
+                            <legend className="text-small font-semibold text-text">
+                                Abilities
+                            </legend>
+                            <p className="text-small text-text-muted">
+                                Choose which resources this token can read or write.
+                            </p>
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                {availableAbilities.map((ability) => (
+                                    <Checkbox
+                                        key={ability.value}
+                                        id={`ability-${ability.value}`}
+                                        name="abilities[]"
+                                        label={ability.label}
+                                        checked={data.abilities.includes(ability.value)}
+                                        onChange={(event) =>
+                                            toggleAbility(ability.value, event.target.checked)
+                                        }
+                                    />
+                                ))}
+                            </div>
+                            {errors.abilities ? (
+                                <p className="text-small text-danger">{errors.abilities}</p>
+                            ) : null}
+                        </fieldset>
+
+                        <div>
+                            <Button type="submit" color="primary" loading={processing}>
+                                Generate token
+                            </Button>
+                        </div>
+                    </form>
+                </Card>
+
+                <Card>
+                    <div className="flex flex-col gap-4">
+                        <h2 className="text-medium font-semibold">Active tokens</h2>
+
+                        {tokens.length === 0 ? (
+                            <p className="text-small text-text-muted">
+                                You have not issued any tokens yet.
+                            </p>
+                        ) : (
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-small">
+                                    <thead className="text-left text-text-muted">
+                                        <tr>
+                                            <th className="py-2 pr-4 font-semibold">Name</th>
+                                            <th className="py-2 pr-4 font-semibold">Abilities</th>
+                                            <th className="py-2 pr-4 font-semibold">Last used</th>
+                                            <th className="py-2 pr-4 font-semibold">Created</th>
+                                            <th className="py-2 font-semibold">
+                                                <span className="sr-only">Actions</span>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {tokens.map((token) => (
+                                            <tr key={token.id} className="border-t border-border">
+                                                <td className="py-3 pr-4 font-medium text-text">
+                                                    {token.name}
+                                                </td>
+                                                <td className="py-3 pr-4 text-text-muted">
+                                                    {token.abilities.length > 0
+                                                        ? token.abilities.join(', ')
+                                                        : '—'}
+                                                </td>
+                                                <td className="py-3 pr-4 text-text-muted">
+                                                    {formatDate(token.last_used_at)}
+                                                </td>
+                                                <td className="py-3 pr-4 text-text-muted">
+                                                    {formatDate(token.created_at)}
+                                                </td>
+                                                <td className="py-3 text-right">
+                                                    <Button
+                                                        type="button"
+                                                        color="danger"
+                                                        onClick={() => revoke(token)}
+                                                    >
+                                                        Revoke
+                                                    </Button>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </div>
+                </Card>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,11 +61,13 @@ Route::middleware(['auth'])->group(function () {
         Route::get('appearance', [AppearanceController::class, 'show'])->name('appearance');
         Route::patch('appearance', [AppearanceController::class, 'update'])->name('appearance.update');
         Route::get('two-factor', [TwoFactorController::class, 'show'])->name('two-factor');
-        Route::get('api-tokens', [ApiTokenController::class, 'show'])->name('api-tokens');
-        Route::post('api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-        Route::delete('api-tokens/{token}', [ApiTokenController::class, 'destroy'])
-            ->whereNumber('token')
-            ->name('api-tokens.destroy');
+        Route::middleware('password.confirm')->group(function () {
+            Route::get('api-tokens', [ApiTokenController::class, 'show'])->name('api-tokens');
+            Route::post('api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
+            Route::delete('api-tokens/{token}', [ApiTokenController::class, 'destroy'])
+                ->whereNumber('token')
+                ->name('api-tokens.destroy');
+        });
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Analytics\RealtimeController as AnalyticsRealtimeContro
 use App\Http\Controllers\Analytics\SourceController as AnalyticsSourceController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Integrations\GoogleController as GoogleIntegrationController;
+use App\Http\Controllers\Settings\ApiTokenController;
 use App\Http\Controllers\Settings\AppearanceController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
@@ -60,6 +61,11 @@ Route::middleware(['auth'])->group(function () {
         Route::get('appearance', [AppearanceController::class, 'show'])->name('appearance');
         Route::patch('appearance', [AppearanceController::class, 'update'])->name('appearance.update');
         Route::get('two-factor', [TwoFactorController::class, 'show'])->name('two-factor');
+        Route::get('api-tokens', [ApiTokenController::class, 'show'])->name('api-tokens');
+        Route::post('api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
+        Route::delete('api-tokens/{token}', [ApiTokenController::class, 'destroy'])
+            ->whereNumber('token')
+            ->name('api-tokens.destroy');
     });
 });
 

--- a/tests/Feature/Console/IssueTokenCommandTest.php
+++ b/tests/Feature/Console/IssueTokenCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('issues a token when all options are supplied non-interactively', function () {
+    $user = User::factory()->create(['email' => 'admin@example.com']);
+
+    $this->artisan('artisanpack:issue-token', [
+        '--user' => 'admin@example.com',
+        '--name' => 'artisanpackui.dev',
+        '--ability' => ['packages:read', 'docs:write'],
+    ])
+        ->expectsOutputToContain('Token generated.')
+        ->expectsOutputToContain('Issued to: admin@example.com')
+        ->expectsOutputToContain('Name: artisanpackui.dev')
+        ->expectsOutputToContain('Abilities: packages:read, docs:write')
+        ->assertSuccessful();
+
+    $token = $user->refresh()->tokens()->firstWhere('name', 'artisanpackui.dev');
+    expect($token)->not->toBeNull()
+        ->and($token->abilities)->toBe(['packages:read', 'docs:write']);
+});
+
+it('fails when the user email does not resolve to a user', function () {
+    $this->artisan('artisanpack:issue-token', [
+        '--user' => 'nobody@example.com',
+        '--name' => 'x',
+        '--ability' => ['packages:read'],
+    ])
+        ->expectsOutputToContain('No user found')
+        ->assertFailed();
+});
+
+it('rejects abilities that are not in the allow-list', function () {
+    $user = User::factory()->create(['email' => 'admin@example.com']);
+
+    $this->artisan('artisanpack:issue-token', [
+        '--user' => 'admin@example.com',
+        '--name' => 'x',
+        '--ability' => ['admin:*'],
+    ])
+        ->expectsOutputToContain('Unknown ability: admin:*')
+        ->assertFailed();
+
+    expect($user->refresh()->tokens()->count())->toBe(0);
+});

--- a/tests/Feature/Settings/ApiTokensTest.php
+++ b/tests/Feature/Settings/ApiTokensTest.php
@@ -6,8 +6,14 @@ use App\Enums\TokenAbility;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia;
 
+function confirmPasswordForApiTokens(): void
+{
+    session()->put('auth.password_confirmed_at', time());
+}
+
 it('renders the api tokens page with the user\'s tokens', function () {
     $user = User::factory()->create();
+    confirmPasswordForApiTokens();
     $user->createToken('artisanpackui.dev', [TokenAbility::PackagesRead->value, TokenAbility::DocsWrite->value]);
 
     $response = $this->actingAs($user)->get(route('dashboard.settings.api-tokens'));
@@ -25,14 +31,33 @@ it('renders the api tokens page with the user\'s tokens', function () {
     );
 });
 
+it('sends no-store cache headers so the freshly issued token cannot be cached', function () {
+    $user = User::factory()->create();
+    confirmPasswordForApiTokens();
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.api-tokens'));
+
+    $response->assertOk();
+    expect($response->headers->get('Cache-Control'))->toContain('no-store');
+});
+
 it('redirects guests away from the api tokens page', function () {
     $response = $this->get(route('dashboard.settings.api-tokens'));
 
     $response->assertRedirect(route('login'));
 });
 
+it('redirects to the password-confirm screen when the password has not been confirmed', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.api-tokens'));
+
+    $response->assertRedirect(route('password.confirm'));
+});
+
 it('issues a new token and flashes it once for display', function () {
     $user = User::factory()->create();
+    confirmPasswordForApiTokens();
 
     $response = $this->actingAs($user)
         ->from(route('dashboard.settings.api-tokens'))
@@ -50,8 +75,32 @@ it('issues a new token and flashes it once for display', function () {
     expect($user->refresh()->tokens()->where('name', 'ci-bot')->exists())->toBeTrue();
 });
 
+it('persists only the sha-256 hash of the token, never the plain text', function () {
+    $user = User::factory()->create();
+    confirmPasswordForApiTokens();
+
+    $this->actingAs($user)
+        ->post(route('dashboard.settings.api-tokens.store'), [
+            'name' => 'ci-bot',
+            'abilities' => ['packages:read'],
+        ])
+        ->assertRedirect();
+
+    /** @var array{name: string, plain_text: string} $flashed */
+    $flashed = session('new_api_token');
+    $plain = $flashed['plain_text'];
+    $stored = $user->refresh()->tokens()->firstWhere('name', 'ci-bot');
+
+    expect($stored)->not->toBeNull()
+        ->and($stored->token)->not->toBe($plain)
+        ->and($stored->token)->not->toContain(explode('|', $plain, 2)[1] ?? $plain)
+        ->and($stored->token)->toHaveLength(64)
+        ->and($stored->token)->toBe(hash('sha256', explode('|', $plain, 2)[1]));
+});
+
 it('rejects tokens with abilities outside the allow-list', function () {
     $user = User::factory()->create();
+    confirmPasswordForApiTokens();
 
     $response = $this->actingAs($user)
         ->from(route('dashboard.settings.api-tokens'))
@@ -67,6 +116,7 @@ it('rejects tokens with abilities outside the allow-list', function () {
 
 it('rejects tokens with no abilities', function () {
     $user = User::factory()->create();
+    confirmPasswordForApiTokens();
 
     $response = $this->actingAs($user)
         ->from(route('dashboard.settings.api-tokens'))
@@ -81,6 +131,7 @@ it('rejects tokens with no abilities', function () {
 
 it('revokes a token that belongs to the current user', function () {
     $user = User::factory()->create();
+    confirmPasswordForApiTokens();
     $token = $user->createToken('to-revoke', [TokenAbility::PackagesRead->value])->accessToken;
 
     $response = $this->actingAs($user)
@@ -95,6 +146,7 @@ it('revokes a token that belongs to the current user', function () {
 it('does not let a user revoke another user\'s token', function () {
     $owner = User::factory()->create();
     $intruder = User::factory()->create();
+    confirmPasswordForApiTokens();
     $token = $owner->createToken('owned', [TokenAbility::PackagesRead->value])->accessToken;
 
     $response = $this->actingAs($intruder)

--- a/tests/Feature/Settings/ApiTokensTest.php
+++ b/tests/Feature/Settings/ApiTokensTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TokenAbility;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+
+it('renders the api tokens page with the user\'s tokens', function () {
+    $user = User::factory()->create();
+    $user->createToken('artisanpackui.dev', [TokenAbility::PackagesRead->value, TokenAbility::DocsWrite->value]);
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.api-tokens'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Settings/ApiTokens')
+        ->has('tokens', 1, fn (AssertableInertia $token) => $token
+            ->where('name', 'artisanpackui.dev')
+            ->where('abilities', ['packages:read', 'docs:write'])
+            ->etc()
+        )
+        ->has('availableAbilities', count(TokenAbility::cases()))
+        ->where('newToken', null)
+    );
+});
+
+it('redirects guests away from the api tokens page', function () {
+    $response = $this->get(route('dashboard.settings.api-tokens'));
+
+    $response->assertRedirect(route('login'));
+});
+
+it('issues a new token and flashes it once for display', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->from(route('dashboard.settings.api-tokens'))
+        ->post(route('dashboard.settings.api-tokens.store'), [
+            'name' => 'ci-bot',
+            'abilities' => ['packages:read', 'docs:read'],
+        ]);
+
+    $response->assertRedirect(route('dashboard.settings.api-tokens'));
+    $response->assertSessionHas('status', 'api-token-created');
+    $response->assertSessionHas('new_api_token', fn (array $token) => $token['name'] === 'ci-bot'
+        && is_string($token['plain_text'])
+        && $token['plain_text'] !== '');
+
+    expect($user->refresh()->tokens()->where('name', 'ci-bot')->exists())->toBeTrue();
+});
+
+it('rejects tokens with abilities outside the allow-list', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->from(route('dashboard.settings.api-tokens'))
+        ->post(route('dashboard.settings.api-tokens.store'), [
+            'name' => 'ci-bot',
+            'abilities' => ['packages:read', 'admin:*'],
+        ]);
+
+    $response->assertRedirect(route('dashboard.settings.api-tokens'));
+    $response->assertSessionHasErrors('abilities.1');
+    expect($user->refresh()->tokens()->count())->toBe(0);
+});
+
+it('rejects tokens with no abilities', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->from(route('dashboard.settings.api-tokens'))
+        ->post(route('dashboard.settings.api-tokens.store'), [
+            'name' => 'ci-bot',
+            'abilities' => [],
+        ]);
+
+    $response->assertSessionHasErrors('abilities');
+    expect($user->refresh()->tokens()->count())->toBe(0);
+});
+
+it('revokes a token that belongs to the current user', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('to-revoke', [TokenAbility::PackagesRead->value])->accessToken;
+
+    $response = $this->actingAs($user)
+        ->from(route('dashboard.settings.api-tokens'))
+        ->delete(route('dashboard.settings.api-tokens.destroy', ['token' => $token->id]));
+
+    $response->assertRedirect(route('dashboard.settings.api-tokens'));
+    $response->assertSessionHas('status', 'api-token-revoked');
+    expect($user->refresh()->tokens()->count())->toBe(0);
+});
+
+it('does not let a user revoke another user\'s token', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $token = $owner->createToken('owned', [TokenAbility::PackagesRead->value])->accessToken;
+
+    $response = $this->actingAs($intruder)
+        ->delete(route('dashboard.settings.api-tokens.destroy', ['token' => $token->id]));
+
+    $response->assertNotFound();
+    expect($owner->refresh()->tokens()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Adds the two remaining pieces of §9.6 of the V2 refactor plan: an in-app UI for issuing/listing/revoking Sanctum personal access tokens, and an artisan command for minting the very first token before the UI is live.

## Related Issue

Closes #105
Closes #106

## Type of Change

- [x] New feature

## Changes

- **`php artisan artisanpack:issue-token`** — interactive or non-interactive (`--user`, `--name`, `--ability=…`) command that mints a Sanctum PAT for a given user and prints the plain-text token once. Abilities are validated against the `TokenAbility` allow-list.
- **`/dashboard/settings/api-tokens` Inertia page** — issue form (name + ability checklist), one-shot plain-text banner for the newly minted token, and a table of active tokens (name, abilities, `last_used_at`, `created_at`) with revoke.
- **`Settings/ApiTokenController`** — `show`/`store`/`destroy`, all under `password.confirm` middleware so an idle session can't silently mint or destroy tokens.
- **`Cache-Control: no-store`** on the show response so the one-shot plain-text banner cannot be recovered from bfcache or an intermediate proxy.
- **Account-menu link** — "API Tokens" added alongside Profile / Password / Appearance / Two-Factor Auth.

## Testing

- [x] Tests added or updated
- [x] Manually tested locally

`tests/Feature/Settings/ApiTokensTest.php` (10 tests):
- Page renders with user's tokens; guests redirected to login; unconfirmed-password users redirected to `password.confirm`.
- Response carries `Cache-Control: no-store`.
- Store issues token, flashes plain-text once, persists **only** the SHA-256 hash in `personal_access_tokens.token`.
- Rejects abilities outside the `TokenAbility` allow-list; rejects empty abilities array.
- Revoke works for own token; another user's DELETE hits 404 (IDOR guard).

`tests/Feature/Console/IssueTokenCommandTest.php` (3 tests):
- Non-interactive happy path; unknown-user failure; unknown-ability rejection.

All 13 tests pass. `vendor/bin/pint --dirty` clean.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)