### PR TITLE
feat: CORS + rate limiting on the API surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,11 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Comma-separated list of origins allowed to hit the /api surface.
+# No wildcards — see V2_REFACTOR_PLAN.md §8.2, §9.6.
+CORS_ALLOWED_ORIGINS=https://artisanpackui.dev
+API_RATE_LIMIT_PER_MINUTE=60
+# Comma-separated CIDRs of reverse proxies allowed to set X-Forwarded-*.
+# Use `*` only if the LB is the sole ingress. Empty = trust none.
+TRUSTED_PROXIES=

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,11 @@ use App\Analytics\DashboardDataSourceManager;
 use App\Http\Middleware\CoerceAnalyticsBeaconTypes;
 use App\Models\User;
 use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\View\FileViewFinder;
@@ -65,6 +68,33 @@ class AppServiceProvider extends ServiceProvider
 
         $this->registerInertiaModulePageNamespaces();
         $this->registerAnalyticsBeaconCoercion();
+        $this->registerApiRateLimiter();
+    }
+
+    /**
+     * Define the `api` rate limiter that guards the remote-admin API
+     * surface (V2_REFACTOR_PLAN.md §8.2, §9.6 #43). Keyed to the
+     * authenticated Sanctum token when present so multiple consumers
+     * from the same NAT don't share a bucket, otherwise to the IP.
+     * Limit is sourced from config so ops can dial it per-environment.
+     */
+    protected function registerApiRateLimiter(): void
+    {
+        RateLimiter::for('api', function (Request $request) {
+            $perMinute = (int) config('artisanpack.api.rate_limit_per_minute', 60);
+
+            // Resolve the caller against the `sanctum` guard explicitly
+            // — the default guard is `web` (session), so
+            // `$request->user()` is null for real Bearer-token traffic
+            // and every authenticated caller would silently collapse
+            // into the IP bucket.
+            $sanctumUser = $request->user('sanctum');
+            $key = $sanctumUser?->currentAccessToken()?->id
+                ?? $sanctumUser?->getAuthIdentifier()
+                ?? $request->ip();
+
+            return Limit::perMinute($perMinute)->by((string) $key);
+        });
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -24,6 +24,31 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
         ]);
 
+        // Trust the configured reverse-proxy layer so `$request->ip()`
+        // returns the real client IP (used as the unauth key for the
+        // `api` rate limiter — V2_REFACTOR_PLAN.md §8.2, §9.6 #43).
+        // Without this, every request collapses to the LB IP and the
+        // API becomes trivially DoSable. Set `TRUSTED_PROXIES` to `*`
+        // only when the LB is the sole ingress; otherwise supply an
+        // explicit comma-separated CIDR list.
+        // env() is used directly here because the config repository
+        // is not bound yet when the middleware builder runs.
+        $proxies = trim((string) env('TRUSTED_PROXIES', ''));
+        if ($proxies !== '') {
+            $middleware->trustProxies(
+                at: $proxies === '*'
+                    ? '*'
+                    : array_values(array_filter(array_map('trim', explode(',', $proxies)))),
+            );
+        }
+
+        // Rate-limit every request in the remote-admin API surface
+        // (V2_REFACTOR_PLAN.md §8.2, §9.6 #43). The `api` limiter is
+        // defined in AppServiceProvider::boot().
+        $middleware->api(prepend: [
+            'throttle:api',
+        ]);
+
         $middleware->alias([
             'abilities' => CheckAbilities::class,
             'ability' => CheckForAnyAbility::class,

--- a/config/artisanpack.php
+++ b/config/artisanpack.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ArtisanPack UI Unified Configuration.
  *
@@ -38,20 +39,29 @@ return [
             ],
             'loading' => [
                 'spinner' => 'o-arrow-path',
-                'dots' => NULL,
-                'ring' => NULL,
-                'custom_svg' => NULL,
+                'dots' => null,
+                'ring' => null,
+                'custom_svg' => null,
                 'default_type' => 'css',
             ],
         ],
         'theme_output_path' => '/Users/jacobmartella/Herd/artisanpack-ui-docs/resources/css/artisanpack-ui-theme.css',
     ],
-	'icons'                  => [
-		'sets' => [
-			'artisanpack' => [
-				'path'   => resource_path( 'icons/artisanpack' ),
-				'prefix' => 'ap',
-			],
-		],
-	],
+    'icons' => [
+        'sets' => [
+            'artisanpack' => [
+                'path' => resource_path('icons/artisanpack'),
+                'prefix' => 'ap',
+            ],
+        ],
+    ],
+
+    /*
+     * Remote-admin API knobs (V2_REFACTOR_PLAN.md §8.2, §9.6 #43).
+     * `rate_limit_per_minute` is consumed by the `api` limiter
+     * registered in AppServiceProvider.
+     */
+    'api' => [
+        'rate_limit_per_minute' => (int) env('API_RATE_LIMIT_PER_MINUTE', 60),
+    ],
 ];

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CORS is restricted to explicitly configured origins per the v3.0
+ * remote-admin API plan (V2_REFACTOR_PLAN.md §8.2, §9.6 #43). No
+ * wildcards — production is the artisanpackui.dev consumer only.
+ * Origins are supplied as a comma-separated list in
+ * CORS_ALLOWED_ORIGINS so ops can rotate them without a deploy.
+ */
+return [
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+
+    'allowed_methods' => ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
+
+    'allowed_origins' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', (string) env('CORS_ALLOWED_ORIGINS', 'https://artisanpackui.dev'))
+    ))),
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['Accept', 'Authorization', 'Content-Type', 'X-Requested-With'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => false,
+];

--- a/tests/Feature/Api/V1/ApiCorsAndThrottleTest.php
+++ b/tests/Feature/Api/V1/ApiCorsAndThrottleTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\RateLimiter;
+use Laravel\Sanctum\Sanctum;
+use Modules\Packages\Package;
+
+beforeEach(function () {
+    RateLimiter::clear('api');
+    config()->set('cors.paths', ['api/*', 'sanctum/csrf-cookie']);
+    config()->set('cors.allowed_methods', ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS']);
+    config()->set('cors.allowed_origins', ['https://artisanpackui.dev']);
+    config()->set('cors.allowed_origins_patterns', []);
+    config()->set('cors.allowed_headers', ['Accept', 'Authorization', 'Content-Type', 'X-Requested-With']);
+    config()->set('cors.supports_credentials', false);
+});
+
+test('CORS preflight from a configured origin is allowed', function () {
+    $response = $this->call(
+        'OPTIONS',
+        '/api/v1/packages',
+        server: [
+            'HTTP_ORIGIN' => 'https://artisanpackui.dev',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET',
+        ],
+    );
+
+    expect($response->headers->get('Access-Control-Allow-Origin'))->toBe('https://artisanpackui.dev');
+});
+
+test('CORS preflight from an unlisted origin is rejected', function () {
+    $response = $this->call(
+        'OPTIONS',
+        '/api/v1/packages',
+        server: [
+            'HTTP_ORIGIN' => 'https://evil.example.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET',
+        ],
+    );
+
+    // The security-critical property: the ACAO header must not echo
+    // the evil origin and must not be `*`. Either would let the
+    // browser hand the response over. (Symfony's CORS middleware
+    // may fall back to the first configured origin here, which the
+    // browser rejects because it doesn't match the request Origin.)
+    $acao = $response->headers->get('Access-Control-Allow-Origin');
+    expect($acao)->not->toBe('https://evil.example.com');
+    expect($acao)->not->toBe('*');
+});
+
+test('CORS response does not enable credentials', function () {
+    $response = $this->call(
+        'OPTIONS',
+        '/api/v1/packages',
+        server: [
+            'HTTP_ORIGIN' => 'https://artisanpackui.dev',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET',
+        ],
+    );
+
+    expect($response->headers->get('Access-Control-Allow-Credentials'))->toBeNull();
+});
+
+test('api throttle isolates buckets per Sanctum token', function () {
+    config()->set('artisanpack.api.rate_limit_per_minute', 2);
+
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    // Burn userA's bucket to zero.
+    Sanctum::actingAs($userA, ['packages:read']);
+    $this->getJson(route('api.v1.packages.index'))->assertOk();
+    $this->getJson(route('api.v1.packages.index'))->assertOk();
+    $this->getJson(route('api.v1.packages.index'))->assertStatus(429);
+
+    // userB — different token — must still be allowed through. If the
+    // limiter silently collapses to IP, this hits 429 too.
+    Sanctum::actingAs($userB, ['packages:read']);
+    $this->getJson(route('api.v1.packages.index'))->assertOk();
+});
+
+test('CORS config declares no wildcard origins', function () {
+    expect(config('cors.allowed_origins'))->not->toContain('*');
+});
+
+test('api routes reject requests once the api throttle limit is exceeded', function () {
+    config()->set('artisanpack.api.rate_limit_per_minute', 3);
+
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['packages:read']);
+    Package::factory()->count(1)->create();
+
+    for ($i = 0; $i < 3; $i++) {
+        $this->getJson(route('api.v1.packages.index'))->assertOk();
+    }
+
+    $this->getJson(route('api.v1.packages.index'))->assertStatus(429);
+});


### PR DESCRIPTION
## Summary

Locks down the v3.0 remote-admin API: restrict CORS to explicitly configured origins (no wildcard), and put every `api/*` request behind a `throttle:api` bucket keyed by Sanctum token (V2_REFACTOR_PLAN.md §8.2, §9.6 #43).

## Related Issue

Closes #107

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- `config/cors.php` restricted to `CORS_ALLOWED_ORIGINS` (default `https://artisanpackui.dev`), scoped to `api/*` + `sanctum/csrf-cookie`, credentials off, no wildcard origins/patterns.
- `throttle:api` prepended to the api middleware group (`bootstrap/app.php`).
- `api` `RateLimiter` registered in `AppServiceProvider`. **Resolves the caller against the `sanctum` guard explicitly** — the default guard is `web`/session, so `$request->user()` is null for real Bearer traffic and every authenticated caller would otherwise silently collapse into a shared IP bucket. Key precedence: `token id → user id → IP`.
- `TRUSTED_PROXIES` wired via `bootstrap/app.php` so `$request->ip()` returns the real client IP behind Cloudflare/Forge — required for the unauth IP bucket to actually segment callers instead of collapsing to the LB address.
- Config knob `artisanpack.api.rate_limit_per_minute` (env `API_RATE_LIMIT_PER_MINUTE`, default 60).
- `.env.example` documents the three new env vars.

## Testing

Six new tests in `tests/Feature/Api/V1/ApiCorsAndThrottleTest.php`:

- Preflight from a configured origin succeeds.
- Preflight from an unlisted origin gets no usable `Access-Control-Allow-Origin` (not the evil origin, not `*`).
- CORS config asserts there is no `*` in `allowed_origins`.
- CORS response does not enable credentials.
- API returns 429 once the configured per-minute limit is exceeded.
- Two Sanctum tokens on the same IP are isolated into separate buckets (regression coverage for the sanctum-guard fix above).

- [x] Tests added or updated
- [x] Manually tested locally

## Deployment note

Production must set `TRUSTED_PROXIES` for the deploy target (Forge / Cloudflare CIDRs, or `*` if the LB is the sole ingress) and `CORS_ALLOWED_ORIGINS` to the artisanpackui.dev origin(s). Empty `TRUSTED_PROXIES` = trust none (safe local default).

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass (32/32 in `tests/Feature/Api/V1/`)
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API request throttling with configurable per-minute limits.
  * Added configurable CORS support for approved origins and API methods.
  * Added reverse-proxy configuration to preserve accurate client IP detection.

* **Bug Fixes**
  * Improved throttle isolation by applying limits per authenticated access token or user, with IP fallback.

* **Tests**
  * Added coverage for CORS preflight behavior, origin restrictions, credential handling, and HTTP 429 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->