### PR TITLE
test: v1 API tests for policies, validation, and reorder round-trip

### DIFF
--- a/tests/Feature/Api/V1/ChangelogApiTest.php
+++ b/tests/Feature/Api/V1/ChangelogApiTest.php
@@ -85,3 +85,41 @@ test('destroy removes a changelog for a token with changelogs:write', function (
 
     $this->assertDatabaseMissing('changelogs', ['id' => $changelog->id]);
 });
+
+test('store is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['changelogs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.changelogs.store', $package), [
+        'title' => '1.0.0',
+        'content' => 'Blocked release.',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('changelogs', ['package_id' => $package->id, 'title' => '1.0.0']);
+});
+
+test('destroy is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['changelogs:write']);
+    $changelog = Changelog::factory()->create();
+
+    $this->deleteJson(route('api.v1.changelogs.destroy', $changelog))->assertForbidden();
+
+    $this->assertDatabaseHas('changelogs', ['id' => $changelog->id]);
+});
+
+test('store rejects invalid payloads with 422', function () {
+    actAsChangelogsToken(['changelogs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.changelogs.store', $package), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('unauthenticated requests are rejected', function () {
+    $package = Package::factory()->create();
+
+    $this->getJson(route('api.v1.packages.changelogs.index', $package))->assertUnauthorized();
+});

--- a/tests/Feature/Api/V1/DocumentationApiTest.php
+++ b/tests/Feature/Api/V1/DocumentationApiTest.php
@@ -151,3 +151,81 @@ test('reorder rejects docs not owned by the package', function () {
         'items' => [['id' => $foreign->id, 'menu_order' => 1]],
     ])->assertStatus(422);
 });
+
+test('store is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['docs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.documentation.store', $package), [
+        'title' => 'Blocked',
+        'slug' => 'blocked',
+        'content' => '# Blocked',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('documentation', ['slug' => 'blocked']);
+});
+
+test('destroy is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['docs:write']);
+    $doc = Documentation::factory()->create();
+
+    $this->deleteJson(route('api.v1.documentation.destroy', $doc))->assertForbidden();
+
+    $this->assertDatabaseHas('documentation', ['id' => $doc->id]);
+});
+
+test('store rejects invalid payloads with 422', function () {
+    actAsDocsToken(['docs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.documentation.store', $package), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['title', 'slug', 'content']);
+});
+
+test('reorder round-trip: new order is visible via the tree endpoint', function () {
+    actAsDocsToken(['docs:read', 'docs:write']);
+    $package = Package::factory()->create();
+
+    $root = Documentation::factory()->for($package)->create([
+        'title' => 'Root', 'parent' => 0, 'menu_order' => 0,
+    ]);
+    $childA = Documentation::factory()->for($package)->create([
+        'title' => 'Child A', 'parent' => $root->id, 'menu_order' => 0,
+    ]);
+    $childB = Documentation::factory()->for($package)->create([
+        'title' => 'Child B', 'parent' => $root->id, 'menu_order' => 1,
+    ]);
+
+    // Baseline: Child A comes first.
+    $before = $this->getJson(route('api.v1.packages.documentation.index', $package))->assertOk();
+    expect($before->json('data.0.children.0.title'))->toBe('Child A')
+        ->and($before->json('data.0.children.1.title'))->toBe('Child B');
+
+    // Reorder both root and child rows in one payload.
+    $this->postJson(route('api.v1.packages.documentation.reorder', $package), [
+        'items' => [
+            ['id' => $root->id, 'menu_order' => 10],
+            ['id' => $childA->id, 'menu_order' => 5],
+            ['id' => $childB->id, 'menu_order' => 1],
+        ],
+    ])->assertOk();
+
+    // Round-trip: the tree endpoint now reflects the new child order.
+    $after = $this->getJson(route('api.v1.packages.documentation.index', $package))->assertOk();
+    expect($after->json('data.0.children.0.title'))->toBe('Child B')
+        ->and($after->json('data.0.children.1.title'))->toBe('Child A')
+        ->and($after->json('data.0.menu_order'))->toBe(10);
+});
+
+test('reorder requires docs:write', function () {
+    actAsDocsToken(['docs:read']);
+    $package = Package::factory()->create();
+    $doc = Documentation::factory()->for($package)->create();
+
+    $this->postJson(route('api.v1.packages.documentation.reorder', $package), [
+        'items' => [['id' => $doc->id, 'menu_order' => 1]],
+    ])->assertForbidden();
+});

--- a/tests/Feature/Api/V1/PackageApiTest.php
+++ b/tests/Feature/Api/V1/PackageApiTest.php
@@ -91,3 +91,35 @@ test('unauthenticated requests are rejected', function () {
 
     $this->getJson(route('api.v1.packages.index'))->assertUnauthorized();
 });
+
+test('store is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['packages:write']);
+
+    $this->postJson(route('api.v1.packages.store'), [
+        'name' => 'Blocked Package',
+        'slug' => 'blocked-package',
+        'wiki_url' => 'https://github.com/artisanpack-ui/blocked/wiki',
+        'changelog_url' => 'https://github.com/artisanpack-ui/blocked/blob/main/CHANGELOG.md',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('packages', ['slug' => 'blocked-package']);
+});
+
+test('destroy is blocked by the policy when the actor is not an admin', function () {
+    $editor = User::factory()->editor()->create();
+    Sanctum::actingAs($editor, ['packages:write']);
+    $package = Package::factory()->create();
+
+    $this->deleteJson(route('api.v1.packages.destroy', $package))->assertForbidden();
+
+    $this->assertDatabaseHas('packages', ['id' => $package->id]);
+});
+
+test('store rejects invalid payloads with 422', function () {
+    actAsToken(['packages:write']);
+
+    $this->postJson(route('api.v1.packages.store'), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name', 'slug', 'changelog_url']);
+});


### PR DESCRIPTION
## Summary

Expands the v1 API Pest suite so the remaining acceptance criteria from V2_REFACTOR_PLAN.md §9.6 #44 are covered: policy enforcement, validation, and a real end-to-end reorder round-trip. Happy-path CRUD and ability-middleware coverage were already in place; this PR fills the gaps.

## Related Issue

Closes #108

## Type of Change

- [x] New feature (test coverage)

## Changes

- Editor (non-admin) with a valid `*:write` ability gets **403** on `store`/`destroy` for `Package`, `Documentation`, and `Changelog`, and the DB is left untouched.
- Empty POST payloads return **422** with the expected validation errors on required fields.
- Documentation reorder round-trip: seed a root + two children, `GET` the tree for a baseline, `POST` a reorder that mutates both parent and child `menu_order`, then `GET` again and assert the new order is reflected.
- `docs:read`-only token cannot hit the reorder endpoint (ability gate holds independently of the policy).
- Adds the missing `unauthenticated → 401` case to the changelog suite for parity with the package suite.

## Testing

- [x] Tests added
- [x] `php artisan test tests/Feature/Api/V1/` — 44 tests, 105 assertions, all passing
- [x] `vendor/bin/pint --dirty` — clean

No production code changed.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass