### PR TITLE
feat: audit log, PAT rotation reminder, and v1 API docs (#109 #110 #111)

### DIFF
--- a/Modules/Packages/app/Http/Controllers/Admin/PackagesController.php
+++ b/Modules/Packages/app/Http/Controllers/Admin/PackagesController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Packages\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuditLogger;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -13,6 +14,8 @@ use Modules\Packages\Package;
 
 class PackagesController extends Controller
 {
+    public function __construct(protected AuditLogger $audit) {}
+
     public function index(): Response
     {
         $packages = Package::query()
@@ -53,6 +56,8 @@ class PackagesController extends Controller
 
         $package = Package::create($this->normalize($request->validated()));
 
+        $this->audit->record(AuditLogger::ACTION_CREATED, $package, null, $package->getAttributes());
+
         return redirect()
             ->route('dashboard.packages.edit', $package)
             ->with('success', 'Package added successfully!');
@@ -89,7 +94,10 @@ class PackagesController extends Controller
 
     public function update(PackageRequest $request, Package $package): RedirectResponse
     {
+        $original = $package->getOriginal();
         $package->update($this->normalize($request->validated()));
+
+        $this->audit->record(AuditLogger::ACTION_UPDATED, $package, $original, $package->getAttributes());
 
         return redirect()
             ->route('dashboard.packages.edit', $package)
@@ -100,7 +108,10 @@ class PackagesController extends Controller
     {
         $this->authorize('delete', $package);
 
+        $snapshot = $package->getOriginal();
         $package->delete();
+
+        $this->audit->record(AuditLogger::ACTION_DELETED, $package, $snapshot, null);
 
         return redirect()
             ->route('dashboard.packages')

--- a/Modules/Packages/app/Http/Controllers/DocumentationReorderController.php
+++ b/Modules/Packages/app/Http/Controllers/DocumentationReorderController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Packages\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuditLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -23,6 +24,8 @@ use Modules\Packages\Package;
  */
 class DocumentationReorderController extends Controller
 {
+    public function __construct(protected AuditLogger $audit) {}
+
     public function __invoke(ReorderDocumentationRequest $request, Package $package): RedirectResponse|JsonResponse
     {
         /** @var array<int, array{id:int, menu_order:int}> $items */
@@ -44,6 +47,8 @@ class DocumentationReorderController extends Controller
                     ->update(['menu_order' => $item['menu_order']]);
             }
         });
+
+        $this->audit->recordReorder($package, $items, $request);
 
         if ($this->wantsJson($request)) {
             return response()->json(['message' => 'Documentation order updated.']);

--- a/app/Http/Controllers/Api/V1/ChangelogController.php
+++ b/app/Http/Controllers/Api/V1/ChangelogController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuditLogger;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -19,6 +20,8 @@ use Modules\Packages\Package;
 class ChangelogController extends Controller
 {
     use AuthorizesRequests;
+
+    public function __construct(protected AuditLogger $audit) {}
 
     public function index(Package $package): AnonymousResourceCollection
     {
@@ -37,12 +40,19 @@ class ChangelogController extends Controller
         $data = $request->validated();
         $data['package_id'] = $package->id;
 
-        return new ChangelogResource(Changelog::create($data));
+        $changelog = Changelog::create($data);
+
+        $this->audit->record(AuditLogger::ACTION_CREATED, $changelog, null, $changelog->getAttributes());
+
+        return new ChangelogResource($changelog);
     }
 
     public function update(ChangelogRequest $request, Changelog $changelog): ChangelogResource
     {
+        $original = $changelog->getOriginal();
         $changelog->update($request->validated());
+
+        $this->audit->record(AuditLogger::ACTION_UPDATED, $changelog, $original, $changelog->getAttributes());
 
         return new ChangelogResource($changelog);
     }
@@ -51,7 +61,10 @@ class ChangelogController extends Controller
     {
         $this->authorize('delete', $changelog);
 
+        $snapshot = $changelog->getOriginal();
         $changelog->delete();
+
+        $this->audit->record(AuditLogger::ACTION_DELETED, $changelog, $snapshot, null);
 
         return response()->json(status: 204);
     }

--- a/app/Http/Controllers/Api/V1/DocumentationController.php
+++ b/app/Http/Controllers/Api/V1/DocumentationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuditLogger;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
@@ -25,6 +26,8 @@ use Modules\Packages\Package;
 class DocumentationController extends Controller
 {
     use AuthorizesRequests;
+
+    public function __construct(protected AuditLogger $audit) {}
 
     /**
      * Nested-tree listing of every doc in the package, ordered by
@@ -50,7 +53,11 @@ class DocumentationController extends Controller
         $data = $request->validated();
         $data['package_id'] = $package->id;
 
-        return new DocumentationResource(Documentation::create($data));
+        $documentation = Documentation::create($data);
+
+        $this->audit->record(AuditLogger::ACTION_CREATED, $documentation, null, $documentation->getAttributes());
+
+        return new DocumentationResource($documentation);
     }
 
     public function show(Documentation $documentation): DocumentationResource
@@ -62,7 +69,10 @@ class DocumentationController extends Controller
 
     public function update(DocumentationRequest $request, Documentation $documentation): DocumentationResource
     {
+        $original = $documentation->getOriginal();
         $documentation->update($request->validated());
+
+        $this->audit->record(AuditLogger::ACTION_UPDATED, $documentation, $original, $documentation->getAttributes());
 
         return new DocumentationResource($documentation);
     }
@@ -71,7 +81,10 @@ class DocumentationController extends Controller
     {
         $this->authorize('delete', $documentation);
 
+        $snapshot = $documentation->getOriginal();
         $documentation->delete();
+
+        $this->audit->record(AuditLogger::ACTION_DELETED, $documentation, $snapshot, null);
 
         return response()->json(status: 204);
     }

--- a/app/Http/Controllers/Api/V1/PackageController.php
+++ b/app/Http/Controllers/Api/V1/PackageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuditLogger;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -22,6 +23,8 @@ class PackageController extends Controller
 {
     use AuthorizesRequests;
 
+    public function __construct(protected AuditLogger $audit) {}
+
     public function index(): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Package::class);
@@ -33,7 +36,11 @@ class PackageController extends Controller
 
     public function store(PackageRequest $request): PackageResource
     {
-        return new PackageResource(Package::create($request->validated()));
+        $package = Package::create($request->validated());
+
+        $this->audit->record(AuditLogger::ACTION_CREATED, $package, null, $package->getAttributes());
+
+        return new PackageResource($package);
     }
 
     public function show(Package $package): PackageResource
@@ -45,7 +52,10 @@ class PackageController extends Controller
 
     public function update(PackageRequest $request, Package $package): PackageResource
     {
+        $original = $package->getOriginal();
         $package->update($request->validated());
+
+        $this->audit->record(AuditLogger::ACTION_UPDATED, $package, $original, $package->getAttributes());
 
         return new PackageResource($package);
     }
@@ -54,7 +64,10 @@ class PackageController extends Controller
     {
         $this->authorize('delete', $package);
 
+        $snapshot = $package->getOriginal();
         $package->delete();
+
+        $this->audit->record(AuditLogger::ACTION_DELETED, $package, $snapshot, null);
 
         return response()->json(status: 204);
     }

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\AuditLog;
+use App\Services\AuditLogger;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Packages\Changelog;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
+
+/**
+ * `/dashboard/audit-log` viewer (V2_REFACTOR_PLAN.md §4.3, §9.6 item #46).
+ *
+ * Admin-only. Renders a paginated feed of every write recorded by
+ * {@see AuditLogger}, with filters for resource type, actor, source,
+ * and date range.
+ */
+class AuditLogController extends Controller
+{
+    /**
+     * Resource types eligible for the resource filter — the short label
+     * shown in the UI paired with the FQCN stored in `resource_type`.
+     *
+     * @var array<string, class-string>
+     */
+    protected const RESOURCE_MAP = [
+        'package' => Package::class,
+        'documentation' => Documentation::class,
+        'changelog' => Changelog::class,
+    ];
+
+    public function index(Request $request): Response
+    {
+        $filters = $this->extractFilters($request);
+
+        $query = AuditLog::query()->with('user:id,name,email');
+
+        if ($filters['resource'] !== null && isset(self::RESOURCE_MAP[$filters['resource']])) {
+            $query->where('resource_type', self::RESOURCE_MAP[$filters['resource']]);
+        }
+
+        if ($filters['actor'] !== null && $filters['actor'] !== '') {
+            $query->where('actor_name', 'like', '%'.$filters['actor'].'%');
+        }
+
+        if ($filters['source'] !== null) {
+            $query->where('source', $filters['source']);
+        }
+
+        if ($filters['from'] !== null) {
+            $query->where('created_at', '>=', $filters['from']);
+        }
+
+        if ($filters['to'] !== null) {
+            $query->where('created_at', '<=', $filters['to']);
+        }
+
+        $entries = $query
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->paginate(25)
+            ->withQueryString();
+
+        $labelFor = array_flip(self::RESOURCE_MAP);
+
+        return Inertia::render('Dashboard/AuditLog', [
+            'entries' => [
+                'data' => $entries->getCollection()->map(fn (AuditLog $entry): array => [
+                    'id' => $entry->id,
+                    'actor_name' => $entry->actor_name,
+                    'user' => $entry->user ? [
+                        'id' => $entry->user->id,
+                        'name' => $entry->user->name,
+                        'email' => $entry->user->email,
+                    ] : null,
+                    'source' => $entry->source,
+                    'resource_type' => $entry->resource_type,
+                    'resource_label' => $labelFor[$entry->resource_type] ?? $entry->resource_type,
+                    'resource_id' => $entry->resource_id,
+                    'action' => $entry->action,
+                    'changes' => $entry->changes,
+                    'ip_address' => $entry->ip_address,
+                    'created_at' => optional($entry->created_at)->toIso8601String(),
+                ])->all(),
+                'meta' => [
+                    'current_page' => $entries->currentPage(),
+                    'last_page' => $entries->lastPage(),
+                    'per_page' => $entries->perPage(),
+                    'total' => $entries->total(),
+                ],
+                'links' => [
+                    'prev' => $entries->previousPageUrl(),
+                    'next' => $entries->nextPageUrl(),
+                ],
+            ],
+            'filters' => [
+                'resource' => $filters['resource'],
+                'actor' => $filters['actor'],
+                'source' => $filters['source'],
+                'from' => $filters['from']?->toDateString(),
+                'to' => $filters['to']?->toDateString(),
+            ],
+            'resourceOptions' => array_map(
+                fn (string $key): array => ['value' => $key, 'label' => ucfirst($key)],
+                array_keys(self::RESOURCE_MAP),
+            ),
+            'sourceOptions' => [
+                ['value' => AuditLogger::SOURCE_WEB, 'label' => 'Web'],
+                ['value' => AuditLogger::SOURCE_API, 'label' => 'API'],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     resource: string|null,
+     *     actor: string|null,
+     *     source: string|null,
+     *     from: Carbon|null,
+     *     to: Carbon|null
+     * }
+     */
+    protected function extractFilters(Request $request): array
+    {
+        $validated = $request->validate([
+            'resource' => ['nullable', 'string', 'in:'.implode(',', array_keys(self::RESOURCE_MAP))],
+            'actor' => ['nullable', 'string', 'max:255'],
+            'source' => ['nullable', 'string', 'in:'.AuditLogger::SOURCE_WEB.','.AuditLogger::SOURCE_API],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date'],
+        ]);
+
+        return [
+            'resource' => $validated['resource'] ?? null,
+            'actor' => $validated['actor'] ?? null,
+            'source' => $validated['source'] ?? null,
+            'from' => isset($validated['from']) ? Carbon::parse($validated['from'])->startOfDay() : null,
+            'to' => isset($validated['to']) ? Carbon::parse($validated['to'])->endOfDay() : null,
+        ];
+    }
+}

--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -8,6 +8,8 @@ use App\Enums\TokenAbility;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -16,11 +18,18 @@ use Symfony\Component\HttpFoundation\Response;
 class ApiTokenController extends Controller
 {
     /**
+     * Age at which a PAT is flagged for rotation on `/settings/api-tokens`
+     * (V2_REFACTOR_PLAN.md §5, §9.6 item #47).
+     */
+    public const ROTATION_AGE_DAYS = 90;
+
+    /**
      * Show the API tokens settings page.
      */
     public function show(Request $request): Response
     {
         $user = $request->user();
+        $threshold = Carbon::now()->subDays(self::ROTATION_AGE_DAYS);
 
         $tokens = $user->tokens()
             ->orderByDesc('created_at')
@@ -34,6 +43,11 @@ class ApiTokenController extends Controller
                 )),
                 'last_used_at' => optional($token->last_used_at)->toIso8601String(),
                 'created_at' => optional($token->created_at)->toIso8601String(),
+                'needs_rotation' => $token->created_at !== null
+                    && $token->created_at->lessThan($threshold),
+                'age_days' => $token->created_at !== null
+                    ? (int) $token->created_at->diffInDays(Carbon::now())
+                    : null,
             ])
             ->all();
 
@@ -42,6 +56,7 @@ class ApiTokenController extends Controller
             'availableAbilities' => TokenAbility::options(),
             'newToken' => $request->session()->get('new_api_token'),
             'status' => $request->session()->get('status'),
+            'rotationAgeDays' => self::ROTATION_AGE_DAYS,
         ])->toResponse($request);
 
         // Prevent bfcache / disk cache / intermediate proxies from retaining
@@ -87,5 +102,55 @@ class ApiTokenController extends Controller
         }
 
         return back()->with('status', 'api-token-revoked');
+    }
+
+    /**
+     * Rotate a stale token: revoke the old one and mint a new token with
+     * the same name and abilities. The plain-text of the fresh token is
+     * flashed to the session exactly like {@see store()} so the user can
+     * copy it once (V2_REFACTOR_PLAN.md §5, §9.6 item #47).
+     */
+    public function rotate(Request $request, int $token): RedirectResponse
+    {
+        $user = $request->user();
+
+        /** @var PersonalAccessToken|null $existing */
+        $existing = $user->tokens()->whereKey($token)->first();
+
+        if ($existing === null) {
+            abort(404);
+        }
+
+        $abilities = array_values(array_filter(
+            (array) $existing->abilities,
+            fn ($ability): bool => is_string($ability) && TokenAbility::isAllowed($ability),
+        ));
+
+        if ($abilities === []) {
+            // A rotated token must carry at least one ability, otherwise
+            // it would be useless. Fall back to revoking so the stale
+            // credential is still removed.
+            $existing->delete();
+
+            return back()->with('status', 'api-token-revoked');
+        }
+
+        $name = $existing->name;
+
+        // Wrap the swap in a transaction so a failed createToken() rolls
+        // back the delete — otherwise the user can be stranded with no
+        // working token if the second write fails mid-flight.
+        $newToken = DB::transaction(function () use ($user, $existing, $name, $abilities) {
+            $existing->delete();
+
+            return $user->createToken($name, $abilities);
+        });
+
+        return back()
+            ->with('status', 'api-token-rotated')
+            ->with('new_api_token', [
+                'name' => $name,
+                'plain_text' => $newToken->plainTextToken,
+            ]);
     }
 }

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Services\AuditLogger;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * Row in the `audit_log` table (V2_REFACTOR_PLAN.md §4.3, §9.6 item #46).
+ *
+ * Written exclusively via {@see AuditLogger}. `updated_at`
+ * is intentionally absent — audit rows are immutable.
+ *
+ * @property int $id
+ * @property int|null $user_id
+ * @property string $actor_name
+ * @property string $source
+ * @property string $resource_type
+ * @property int|null $resource_id
+ * @property string $action
+ * @property array<string, array{0: mixed, 1: mixed}>|null $changes
+ * @property string|null $ip_address
+ * @property Carbon $created_at
+ */
+class AuditLog extends Model
+{
+    protected $table = 'audit_log';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'actor_name',
+        'source',
+        'resource_type',
+        'resource_id',
+        'action',
+        'changes',
+        'ip_address',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'changes' => 'array',
+            'created_at' => 'datetime',
+            'resource_id' => 'integer',
+            'user_id' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/AuditLogger.php
+++ b/app/Services/AuditLogger.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Writes rows to the `audit_log` table (V2_REFACTOR_PLAN.md §4.3,
+ * §9.6 item #46).
+ *
+ * Invoke from web and API controllers after every successful write to
+ * Packages / Documentation / Changelogs. The service resolves actor,
+ * source, and IP from the current request so callers only supply what
+ * they're changing.
+ */
+class AuditLogger
+{
+    public const SOURCE_WEB = 'web';
+
+    public const SOURCE_API = 'api';
+
+    public const ACTION_CREATED = 'created';
+
+    public const ACTION_UPDATED = 'updated';
+
+    public const ACTION_DELETED = 'deleted';
+
+    public const ACTION_REORDERED = 'reordered';
+
+    /**
+     * Record a write against a single model.
+     *
+     * `$original` is the model's `getOriginal()` snapshot from BEFORE
+     * the change; `$changed` is the model's current attributes. The
+     * service computes the diff and only stores keys that actually
+     * moved so the JSON payload stays small.
+     *
+     * @param  array<string, mixed>|null  $original
+     * @param  array<string, mixed>|null  $changed
+     */
+    public function record(
+        string $action,
+        Model $resource,
+        ?array $original = null,
+        ?array $changed = null,
+        ?Request $request = null,
+    ): AuditLog {
+        $request ??= request();
+
+        $diff = $this->diff($original, $changed);
+
+        return AuditLog::create([
+            'user_id' => $this->resolveUserId($request),
+            'actor_name' => $this->resolveActorName($request),
+            'source' => $this->resolveSource($request),
+            'resource_type' => $resource::class,
+            'resource_id' => $resource->getKey(),
+            'action' => $action,
+            'changes' => $diff === [] ? null : $diff,
+            'ip_address' => $request?->ip(),
+            'created_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Record a reorder — where the changed payload is a positional map
+     * rather than an attribute diff, so we store it verbatim under a
+     * single `order` key.
+     *
+     * @param  array<int, array{id: int, menu_order: int}>  $items
+     */
+    public function recordReorder(
+        Model $resource,
+        array $items,
+        ?Request $request = null,
+    ): AuditLog {
+        $request ??= request();
+
+        return AuditLog::create([
+            'user_id' => $this->resolveUserId($request),
+            'actor_name' => $this->resolveActorName($request),
+            'source' => $this->resolveSource($request),
+            'resource_type' => $resource::class,
+            'resource_id' => $resource->getKey(),
+            'action' => self::ACTION_REORDERED,
+            'changes' => ['order' => $items],
+            'ip_address' => $request?->ip(),
+            'created_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $original
+     * @param  array<string, mixed>|null  $changed
+     * @return array<string, array{0: mixed, 1: mixed}>
+     */
+    protected function diff(?array $original, ?array $changed): array
+    {
+        if ($original === null && $changed === null) {
+            return [];
+        }
+
+        if ($original === null) {
+            // Creation: every non-null attribute is "new".
+            return collect($changed ?? [])
+                ->filter(fn ($value): bool => $value !== null)
+                ->mapWithKeys(fn ($value, string $key): array => [$key => [null, $value]])
+                ->all();
+        }
+
+        if ($changed === null) {
+            // Deletion: capture the pre-delete snapshot for forensics.
+            return collect($original)
+                ->mapWithKeys(fn ($value, string $key): array => [$key => [$value, null]])
+                ->all();
+        }
+
+        $keys = array_unique(array_merge(array_keys($original), array_keys($changed)));
+        $diff = [];
+
+        foreach ($keys as $key) {
+            $before = $original[$key] ?? null;
+            $after = $changed[$key] ?? null;
+
+            if ($before === $after) {
+                continue;
+            }
+
+            $diff[$key] = [$before, $after];
+        }
+
+        return $diff;
+    }
+
+    protected function resolveUserId(?Request $request): ?int
+    {
+        $user = $request?->user();
+
+        return $user instanceof User ? $user->getKey() : null;
+    }
+
+    protected function resolveActorName(?Request $request): string
+    {
+        $user = $request?->user();
+
+        if ($user === null) {
+            return 'system';
+        }
+
+        // On API requests the acting Sanctum token exposes its name
+        // (e.g. "artisanpackui.dev production"); prefer that over the
+        // owning user because rotation matters at the token level.
+        $token = method_exists($user, 'currentAccessToken')
+            ? $user->currentAccessToken()
+            : null;
+
+        if ($token instanceof PersonalAccessToken && $token->name !== '') {
+            return $user->name.' ('.$token->name.')';
+        }
+
+        return $user->name;
+    }
+
+    protected function resolveSource(?Request $request): string
+    {
+        if ($request === null) {
+            return self::SOURCE_WEB;
+        }
+
+        if ($request->is('api/*') || $request->expectsJson()) {
+            return self::SOURCE_API;
+        }
+
+        return self::SOURCE_WEB;
+    }
+}

--- a/database/migrations/2026_07_25_192434_create_audit_log_table.php
+++ b/database/migrations/2026_07_25_192434_create_audit_log_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Audit-log table (V2_REFACTOR_PLAN.md §4.3, §9.6 item #46).
+ *
+ * Records every write to Packages / Documentation / Changelogs from
+ * both the web admin and the v1 API so admins have a single feed at
+ * `/dashboard/audit-log` showing who changed what, when, and how.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_log', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('actor_name');
+            $table->string('source', 16);
+            $table->string('resource_type', 64);
+            $table->unsignedBigInteger('resource_id')->nullable();
+            $table->string('action', 32);
+            $table->json('changes')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['resource_type', 'resource_id']);
+            $table->index('user_id');
+            $table->index('source');
+            $table->index('action');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_log');
+    }
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,222 @@
+# ArtisanPack UI Docs — v1 remote-admin API
+
+Spec for the Sanctum-guarded API that `artisanpackui.dev` (and any other
+approved client) uses to manage packages, documentation, and changelogs
+on this site.
+
+Ref: [V2_REFACTOR_PLAN.md](../V2_REFACTOR_PLAN.md) §4.2, §4.3, §8.2, §9.6.
+
+## 1. Base URL & auth
+
+- **Prefix:** `/api/v1`
+- **Auth:** every request requires
+  `Authorization: Bearer <personal-access-token>` carrying at least one
+  of the [abilities](#3-abilities) below.
+- **Token issuance:** admins mint tokens at
+  `/dashboard/settings/api-tokens` or via
+  `php artisan artisanpack:issue-token`. Tokens are shown once —
+  copy them immediately.
+- **Rotation:** tokens older than **90 days** are flagged on
+  `/dashboard/settings/api-tokens` with a "rotate" action.
+
+## 2. Rate limiting & CORS
+
+- All `/api/*` traffic runs through the `throttle:api` limiter
+  (`AppServiceProvider::boot()`). Anonymous requests are keyed by client
+  IP; authenticated requests by user id.
+- CORS is restricted to the origins in `CORS_ALLOWED_ORIGINS`
+  (`config/cors.php`). Preflight from any other origin is rejected.
+
+## 3. Abilities
+
+The bounded allow-list from `App\Enums\TokenAbility`:
+
+| Ability             | Grants                                            |
+|---------------------|---------------------------------------------------|
+| `packages:read`     | List / show any package                           |
+| `packages:write`    | Create, update, delete packages                   |
+| `docs:read`         | List / show documentation                         |
+| `docs:write`        | Create, update, delete, reorder documentation     |
+| `changelogs:read`   | List changelogs                                   |
+| `changelogs:write`  | Create, update, delete changelogs                 |
+
+A token without the required ability for a route receives **403**.
+
+## 4. Error envelope
+
+Errors are the standard Laravel JSON shape. Callers should treat
+non-2xx responses as failures and read `message` for a user-visible
+string.
+
+**Validation (422)**
+
+```json
+{
+    "message": "The name field is required. (and 1 more error)",
+    "errors": {
+        "name": ["The name field is required."],
+        "slug": ["The slug field is required."]
+    }
+}
+```
+
+**Auth / ability (401, 403)**
+
+```json
+{ "message": "Unauthenticated." }
+```
+
+```json
+{ "message": "Invalid ability provided." }
+```
+
+**Not found (404)**
+
+```json
+{ "message": "No query results for model [Modules\\Packages\\Package] 42" }
+```
+
+**Rate limit (429)**
+
+Standard `Retry-After` header plus:
+
+```json
+{ "message": "Too Many Attempts." }
+```
+
+## 5. Endpoints
+
+Every write is written to the [audit log](../V2_REFACTOR_PLAN.md#43-audit-log)
+and visible at `/dashboard/audit-log` for admins.
+
+### 5.1 Packages
+
+| Method & URL                                | Ability            | Response       |
+|---------------------------------------------|--------------------|----------------|
+| `GET    /api/v1/packages`                   | `packages:read`    | 200 collection |
+| `GET    /api/v1/packages/{package}`         | `packages:read`    | 200 resource   |
+| `POST   /api/v1/packages`                   | `packages:write`   | 201 resource   |
+| `PATCH  /api/v1/packages/{package}`         | `packages:write`   | 200 resource   |
+| `DELETE /api/v1/packages/{package}`         | `packages:write`   | 204 empty      |
+
+**Package payload (create / update)**
+
+| Field              | Type    | Required | Notes                                     |
+|--------------------|---------|----------|-------------------------------------------|
+| `name`             | string  | ✓        | Max 255                                   |
+| `slug`             | string  | ✓        | Max 255                                   |
+| `wiki_url`         | url     | one of\* | Must be a GitHub/GitLab URL               |
+| `docs_url`         | url     | one of\* | Must be a GitHub URL                      |
+| `changelog_url`    | url     | ✓        | Must be a GitHub/GitLab URL               |
+| `homepage`         | integer | –        |                                           |
+| `icon`             | string  | –        |                                           |
+| `version`          | string  | –        |                                           |
+| `package_registry` | enum    | –        | `packagist` \| `npm`                      |
+
+\* One of `wiki_url` / `docs_url` is required.
+
+**Resource shape** (`PackageResource`)
+
+```json
+{
+    "data": {
+        "id": 42,
+        "name": "ArtisanPack UI React",
+        "slug": "react",
+        "homepage": null,
+        "wiki_url": "https://github.com/artisanpack-ui/react/wiki",
+        "docs_url": null,
+        "changelog_url": "https://github.com/artisanpack-ui/react/blob/main/CHANGELOG.md",
+        "icon": null,
+        "version": "3.0.0",
+        "package_registry": "npm",
+        "created_at": "2026-01-01T00:00:00.000000Z",
+        "updated_at": "2026-07-25T12:00:00.000000Z"
+    }
+}
+```
+
+### 5.2 Documentation
+
+| Method & URL                                                   | Ability         |
+|----------------------------------------------------------------|-----------------|
+| `GET    /api/v1/packages/{package}/documentation`              | `docs:read`     |
+| `GET    /api/v1/documentation/{documentation}`                 | `docs:read`     |
+| `POST   /api/v1/packages/{package}/documentation`              | `docs:write`    |
+| `PATCH  /api/v1/documentation/{documentation}`                 | `docs:write`    |
+| `DELETE /api/v1/documentation/{documentation}`                 | `docs:write`    |
+| `POST   /api/v1/packages/{package}/documentation/reorder`      | `docs:write`    |
+
+- `GET .../documentation` returns a **nested tree** keyed by `children`,
+  ordered by `menu_order` within each parent.
+- `package_id` is pinned to the URL / existing owner — a `docs:write`
+  token cannot move a doc between packages by injecting `package_id`
+  into the PATCH body.
+- Reorder is throttled to `60/minute` on top of `throttle:api`.
+
+**Documentation payload**
+
+| Field              | Type    | Required | Notes                             |
+|--------------------|---------|----------|-----------------------------------|
+| `title`            | string  | ✓        | Max 255                           |
+| `slug`             | string  | ✓        | Max 255                           |
+| `content`          | string  | ✓        | Markdown                          |
+| `parent`           | integer | –        | Parent doc id (`0` = top-level)   |
+| `menu_order`       | integer | –        | ≥ 0                               |
+| `meta_description` | string  | –        | Max 255                           |
+
+**Reorder payload**
+
+```json
+{
+    "items": [
+        { "id": 12, "menu_order": 0 },
+        { "id": 13, "menu_order": 1 }
+    ]
+}
+```
+
+Response (JSON):
+
+```json
+{ "message": "Documentation order updated." }
+```
+
+### 5.3 Changelogs
+
+| Method & URL                                       | Ability             |
+|----------------------------------------------------|---------------------|
+| `GET    /api/v1/packages/{package}/changelogs`     | `changelogs:read`   |
+| `POST   /api/v1/packages/{package}/changelogs`     | `changelogs:write`  |
+| `PATCH  /api/v1/changelogs/{changelog}`            | `changelogs:write`  |
+| `DELETE /api/v1/changelogs/{changelog}`            | `changelogs:write`  |
+
+**Changelog payload**
+
+| Field     | Type   | Required | Notes    |
+|-----------|--------|----------|----------|
+| `title`   | string | –        | Max 255  |
+| `content` | string | ✓        | Markdown |
+
+`package_id` is pinned server-side, same rule as Documentation.
+
+## 6. Audit log
+
+Every successful write to Packages / Documentation / Changelogs — from
+this API **or** the admin UI — is recorded in `audit_log` with:
+`user_id`, `actor_name` (includes token name on API writes), `source`
+(`web` | `api`), `resource_type`, `resource_id`, `action`
+(`created` | `updated` | `deleted` | `reordered`), a JSON diff of
+changed attributes, `ip_address`, `created_at`.
+
+Surfaced at `/dashboard/audit-log` (admin only) with filters for
+resource, actor, source, and date range.
+
+## 7. Try it locally (Bruno)
+
+A Bruno collection lives at [`docs/api/bruno/`](api/bruno/). Import the
+folder into [Bruno](https://www.usebruno.com/) and set two environment
+variables in the `local` environment:
+
+- `base_url` — e.g. `http://artisanpack-ui-docs.test`
+- `token` — a PAT you minted at `/dashboard/settings/api-tokens`

--- a/docs/api/bruno/Changelogs/Create changelog.bru
+++ b/docs/api/bruno/Changelogs/Create changelog.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Create changelog
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{base_url}}/api/v1/packages/:package/changelogs
+  body: json
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "title": "v3.0.0",
+    "content": "## Added\n\n- Initial release."
+  }
+}
+
+docs {
+  Requires the `changelogs:write` ability. `package_id` is pinned to the
+  URL — do not send it in the body.
+}

--- a/docs/api/bruno/Changelogs/Delete changelog.bru
+++ b/docs/api/bruno/Changelogs/Delete changelog.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Delete changelog
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{base_url}}/api/v1/changelogs/:changelog
+  body: none
+  auth: bearer
+}
+
+params:path {
+  changelog: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `changelogs:write` ability. Returns 204 on success.
+}

--- a/docs/api/bruno/Changelogs/List changelogs.bru
+++ b/docs/api/bruno/Changelogs/List changelogs.bru
@@ -1,0 +1,27 @@
+meta {
+  name: List changelogs
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/api/v1/packages/:package/changelogs
+  body: none
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `changelogs:read` ability. Newest-first.
+}

--- a/docs/api/bruno/Changelogs/Update changelog.bru
+++ b/docs/api/bruno/Changelogs/Update changelog.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Update changelog
+  type: http
+  seq: 3
+}
+
+patch {
+  url: {{base_url}}/api/v1/changelogs/:changelog
+  body: json
+  auth: bearer
+}
+
+params:path {
+  changelog: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "title": "v3.0.1",
+    "content": "## Fixed\n\n- Something."
+  }
+}
+
+docs {
+  Requires the `changelogs:write` ability. `package_id` cannot be moved
+  via this endpoint — it's pinned to the changelog's current owner.
+}

--- a/docs/api/bruno/Documentation/Create documentation.bru
+++ b/docs/api/bruno/Documentation/Create documentation.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Create documentation
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base_url}}/api/v1/packages/:package/documentation
+  body: json
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "title": "Getting started",
+    "slug": "getting-started",
+    "parent": 0,
+    "menu_order": 0,
+    "content": "# Getting started\n\nHello!"
+  }
+}
+
+docs {
+  Requires the `docs:write` ability. `package_id` is pinned to the URL —
+  do not send it in the body.
+}

--- a/docs/api/bruno/Documentation/Delete documentation.bru
+++ b/docs/api/bruno/Documentation/Delete documentation.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Delete documentation
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{base_url}}/api/v1/documentation/:documentation
+  body: none
+  auth: bearer
+}
+
+params:path {
+  documentation: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `docs:write` ability. Returns 204 on success.
+}

--- a/docs/api/bruno/Documentation/List documentation tree.bru
+++ b/docs/api/bruno/Documentation/List documentation tree.bru
@@ -1,0 +1,28 @@
+meta {
+  name: List documentation tree
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/api/v1/packages/:package/documentation
+  body: none
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `docs:read` ability. Returns a nested tree grouped by
+  `parent` and ordered by `menu_order`.
+}

--- a/docs/api/bruno/Documentation/Reorder documentation.bru
+++ b/docs/api/bruno/Documentation/Reorder documentation.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Reorder documentation
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{base_url}}/api/v1/packages/:package/documentation/reorder
+  body: json
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "items": [
+      { "id": 12, "menu_order": 0 },
+      { "id": 13, "menu_order": 1 }
+    ]
+  }
+}
+
+docs {
+  Requires the `docs:write` ability. Only `menu_order` is mutated — the
+  parent/child structure comes from the imported GitHub docs. Throttled
+  to 60 requests/minute on top of the global `throttle:api` limiter.
+}

--- a/docs/api/bruno/Documentation/Show documentation.bru
+++ b/docs/api/bruno/Documentation/Show documentation.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Show documentation
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{base_url}}/api/v1/documentation/:documentation
+  body: none
+  auth: bearer
+}
+
+params:path {
+  documentation: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `docs:read` ability.
+}

--- a/docs/api/bruno/Documentation/Update documentation.bru
+++ b/docs/api/bruno/Documentation/Update documentation.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Update documentation
+  type: http
+  seq: 4
+}
+
+patch {
+  url: {{base_url}}/api/v1/documentation/:documentation
+  body: json
+  auth: bearer
+}
+
+params:path {
+  documentation: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "title": "Getting started (v2)",
+    "slug": "getting-started",
+    "parent": 0,
+    "menu_order": 0,
+    "content": "# Getting started (v2)"
+  }
+}
+
+docs {
+  Requires the `docs:write` ability. `package_id` cannot be moved via
+  this endpoint — it's pinned to the doc's current owner.
+}

--- a/docs/api/bruno/Packages/Create package.bru
+++ b/docs/api/bruno/Packages/Create package.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Create package
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base_url}}/api/v1/packages
+  body: json
+  auth: bearer
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "name": "ArtisanPack UI React",
+    "slug": "react",
+    "wiki_url": "https://github.com/artisanpack-ui/react/wiki",
+    "changelog_url": "https://github.com/artisanpack-ui/react/blob/main/CHANGELOG.md",
+    "package_registry": "npm",
+    "version": "3.0.0"
+  }
+}
+
+docs {
+  Requires the `packages:write` ability. Returns 201 with the created
+  resource under `data`.
+}

--- a/docs/api/bruno/Packages/Delete package.bru
+++ b/docs/api/bruno/Packages/Delete package.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Delete package
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{base_url}}/api/v1/packages/:package
+  body: none
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `packages:write` ability. Returns 204 on success.
+}

--- a/docs/api/bruno/Packages/List packages.bru
+++ b/docs/api/bruno/Packages/List packages.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List packages
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/api/v1/packages
+  body: none
+  auth: bearer
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `packages:read` ability.
+}

--- a/docs/api/bruno/Packages/Show package.bru
+++ b/docs/api/bruno/Packages/Show package.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Show package
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{base_url}}/api/v1/packages/:package
+  body: none
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Requires the `packages:read` ability. `:package` is the numeric id.
+}

--- a/docs/api/bruno/Packages/Update package.bru
+++ b/docs/api/bruno/Packages/Update package.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Update package
+  type: http
+  seq: 4
+}
+
+patch {
+  url: {{base_url}}/api/v1/packages/:package
+  body: json
+  auth: bearer
+}
+
+params:path {
+  package: 1
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "name": "ArtisanPack UI React",
+    "slug": "react",
+    "wiki_url": "https://github.com/artisanpack-ui/react/wiki",
+    "changelog_url": "https://github.com/artisanpack-ui/react/blob/main/CHANGELOG.md",
+    "version": "3.1.0"
+  }
+}
+
+docs {
+  Requires the `packages:write` ability. Send the full payload — this
+  is a PATCH but the underlying validator treats every field as
+  present-or-null.
+}

--- a/docs/api/bruno/bruno.json
+++ b/docs/api/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "ArtisanPack UI Docs — v1 API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/docs/api/bruno/environments/local.bru
+++ b/docs/api/bruno/environments/local.bru
@@ -1,0 +1,4 @@
+vars {
+  base_url: http://artisanpack-ui-docs.test
+  token: replace-with-a-real-personal-access-token
+}

--- a/resources/js/layouts/AdminLayout.tsx
+++ b/resources/js/layouts/AdminLayout.tsx
@@ -28,6 +28,7 @@ const DEFAULT_NAV: AdminNavItem[] = [
     { label: 'Users', href: '/dashboard/users', roles: ['admin'] },
     { label: 'Integrations', href: '/dashboard/integrations/google', matchPrefix: '/dashboard/integrations', roles: ['admin'] },
     { label: 'Privacy', href: '/dashboard/privacy', matchPrefix: '/dashboard/privacy', roles: ['admin'] },
+    { label: 'Audit Log', href: '/dashboard/audit-log', matchPrefix: '/dashboard/audit-log', roles: ['admin'] },
     { label: 'Settings', href: '/dashboard/settings', matchPrefix: '/dashboard/settings', roles: ['admin'] },
 ];
 

--- a/resources/js/pages/Dashboard/AuditLog.tsx
+++ b/resources/js/pages/Dashboard/AuditLog.tsx
@@ -1,0 +1,304 @@
+import { Head, router } from '@inertiajs/react';
+import { Button, Input, Select } from '@artisanpack-ui/react/form';
+import { Card } from '@artisanpack-ui/react/layout';
+import { useState, type FormEventHandler } from 'react';
+
+import { AdminLayout } from '../../layouts/AdminLayout';
+
+interface UserRef {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface AuditEntry {
+    id: number;
+    actor_name: string;
+    user: UserRef | null;
+    source: 'web' | 'api';
+    resource_type: string;
+    resource_label: string;
+    resource_id: number | null;
+    action: 'created' | 'updated' | 'deleted' | 'reordered';
+    changes: Record<string, unknown> | null;
+    ip_address: string | null;
+    created_at: string | null;
+}
+
+interface Option {
+    value: string;
+    label: string;
+}
+
+interface AuditLogProps {
+    entries: {
+        data: AuditEntry[];
+        meta: {
+            current_page: number;
+            last_page: number;
+            per_page: number;
+            total: number;
+        };
+        links: {
+            prev: string | null;
+            next: string | null;
+        };
+    };
+    filters: {
+        resource: string | null;
+        actor: string | null;
+        source: string | null;
+        from: string | null;
+        to: string | null;
+    };
+    resourceOptions: Option[];
+    sourceOptions: Option[];
+}
+
+function formatDate(value: string | null): string {
+    if (!value) {
+        return '—';
+    }
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
+}
+
+const ACTION_COLOR: Record<AuditEntry['action'], string> = {
+    created: 'bg-success/15 text-success',
+    updated: 'bg-info/15 text-info',
+    deleted: 'bg-danger/15 text-danger',
+    reordered: 'bg-warning/15 text-warning',
+};
+
+export default function AuditLog({ entries, filters, resourceOptions, sourceOptions }: AuditLogProps) {
+    const [form, setForm] = useState({
+        resource: filters.resource ?? '',
+        actor: filters.actor ?? '',
+        source: filters.source ?? '',
+        from: filters.from ?? '',
+        to: filters.to ?? '',
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+        router.get(
+            '/dashboard/audit-log',
+            Object.fromEntries(Object.entries(form).filter(([, value]) => value !== '')),
+            { preserveScroll: true, preserveState: true },
+        );
+    };
+
+    const reset = () => {
+        setForm({ resource: '', actor: '', source: '', from: '', to: '' });
+        router.get('/dashboard/audit-log', {}, { preserveScroll: true });
+    };
+
+    return (
+        <AdminLayout title="Audit log">
+            <Head title="Audit log" />
+
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+                <header>
+                    <h1 className="text-large font-semibold">Audit log</h1>
+                    <p className="text-small text-text-muted">
+                        Every write to packages, documentation, and changelogs — from
+                        both the admin UI and the v1 API — is recorded here.
+                    </p>
+                </header>
+
+                <Card>
+                    <form onSubmit={submit} className="flex flex-col gap-4" noValidate>
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+                            <Select
+                                id="resource"
+                                name="resource"
+                                label="Resource"
+                                value={form.resource}
+                                onChange={(event) => setForm({ ...form, resource: event.target.value })}
+                            >
+                                <option value="">All resources</option>
+                                {resourceOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </Select>
+
+                            <Input
+                                id="actor"
+                                name="actor"
+                                type="text"
+                                label="Actor"
+                                placeholder="Name or token"
+                                value={form.actor}
+                                onChange={(event) => setForm({ ...form, actor: event.target.value })}
+                            />
+
+                            <Select
+                                id="source"
+                                name="source"
+                                label="Source"
+                                value={form.source}
+                                onChange={(event) => setForm({ ...form, source: event.target.value })}
+                            >
+                                <option value="">Any</option>
+                                {sourceOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </Select>
+
+                            <Input
+                                id="from"
+                                name="from"
+                                type="date"
+                                label="From"
+                                value={form.from}
+                                onChange={(event) => setForm({ ...form, from: event.target.value })}
+                            />
+
+                            <Input
+                                id="to"
+                                name="to"
+                                type="date"
+                                label="To"
+                                value={form.to}
+                                onChange={(event) => setForm({ ...form, to: event.target.value })}
+                            />
+                        </div>
+
+                        <div className="flex gap-2">
+                            <Button type="submit" color="primary">
+                                Apply filters
+                            </Button>
+                            <Button type="button" color="secondary" onClick={reset}>
+                                Reset
+                            </Button>
+                        </div>
+                    </form>
+                </Card>
+
+                <Card>
+                    <div className="flex flex-col gap-4">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-medium font-semibold">
+                                {entries.meta.total} {entries.meta.total === 1 ? 'entry' : 'entries'}
+                            </h2>
+                            <p className="text-small text-text-muted">
+                                Page {entries.meta.current_page} of {entries.meta.last_page}
+                            </p>
+                        </div>
+
+                        {entries.data.length === 0 ? (
+                            <p className="text-small text-text-muted">
+                                No entries match the current filters.
+                            </p>
+                        ) : (
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-small">
+                                    <thead className="text-left text-text-muted">
+                                        <tr>
+                                            <th className="py-2 pr-4 font-semibold">When</th>
+                                            <th className="py-2 pr-4 font-semibold">Actor</th>
+                                            <th className="py-2 pr-4 font-semibold">Source</th>
+                                            <th className="py-2 pr-4 font-semibold">Resource</th>
+                                            <th className="py-2 pr-4 font-semibold">Action</th>
+                                            <th className="py-2 pr-4 font-semibold">Changes</th>
+                                            <th className="py-2 font-semibold">IP</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {entries.data.map((entry) => (
+                                            <tr
+                                                key={entry.id}
+                                                className="border-t border-border align-top"
+                                                data-testid={`audit-row-${entry.id}`}
+                                            >
+                                                <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
+                                                    {formatDate(entry.created_at)}
+                                                </td>
+                                                <td className="py-3 pr-4 font-medium text-text">
+                                                    {entry.actor_name}
+                                                    {entry.user ? (
+                                                        <div className="text-xsmall text-text-muted">
+                                                            {entry.user.email}
+                                                        </div>
+                                                    ) : null}
+                                                </td>
+                                                <td className="py-3 pr-4">
+                                                    <span className="rounded-box bg-surface px-2 py-0.5 text-xsmall uppercase tracking-wide text-text-muted">
+                                                        {entry.source}
+                                                    </span>
+                                                </td>
+                                                <td className="py-3 pr-4 text-text-muted">
+                                                    <span className="font-medium capitalize text-text">
+                                                        {entry.resource_label}
+                                                    </span>
+                                                    {entry.resource_id !== null ? (
+                                                        <span className="ml-1 text-text-muted">
+                                                            #{entry.resource_id}
+                                                        </span>
+                                                    ) : null}
+                                                </td>
+                                                <td className="py-3 pr-4">
+                                                    <span
+                                                        className={`rounded-box px-2 py-0.5 text-xsmall font-semibold uppercase ${
+                                                            ACTION_COLOR[entry.action] ?? 'bg-surface text-text-muted'
+                                                        }`}
+                                                    >
+                                                        {entry.action}
+                                                    </span>
+                                                </td>
+                                                <td className="py-3 pr-4 text-text-muted">
+                                                    {entry.changes ? (
+                                                        <details>
+                                                            <summary className="cursor-pointer text-text hover:text-primary">
+                                                                {Object.keys(entry.changes).length} field
+                                                                {Object.keys(entry.changes).length === 1 ? '' : 's'}
+                                                            </summary>
+                                                            <pre className="mt-2 max-h-64 overflow-auto rounded-box bg-surface p-2 text-xsmall">
+                                                                {JSON.stringify(entry.changes, null, 2)}
+                                                            </pre>
+                                                        </details>
+                                                    ) : (
+                                                        '—'
+                                                    )}
+                                                </td>
+                                                <td className="py-3 text-text-muted font-mono text-xsmall">
+                                                    {entry.ip_address ?? '—'}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+
+                        <div className="flex justify-end gap-2">
+                            <Button
+                                type="button"
+                                color="secondary"
+                                disabled={!entries.links.prev}
+                                onClick={() => entries.links.prev && router.get(entries.links.prev)}
+                            >
+                                Previous
+                            </Button>
+                            <Button
+                                type="button"
+                                color="secondary"
+                                disabled={!entries.links.next}
+                                onClick={() => entries.links.next && router.get(entries.links.next)}
+                            >
+                                Next
+                            </Button>
+                        </div>
+                    </div>
+                </Card>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/resources/js/pages/Settings/ApiTokens.tsx
+++ b/resources/js/pages/Settings/ApiTokens.tsx
@@ -12,6 +12,8 @@ interface TokenSummary {
     abilities: string[];
     last_used_at: string | null;
     created_at: string | null;
+    needs_rotation: boolean;
+    age_days: number | null;
 }
 
 interface AbilityOption {
@@ -29,6 +31,7 @@ interface ApiTokensProps {
     availableAbilities: AbilityOption[];
     newToken: NewToken | null;
     status: string | null;
+    rotationAgeDays: number;
 }
 
 type CreateForm = {
@@ -39,6 +42,7 @@ type CreateForm = {
 const STATUS_MESSAGES: Record<string, string> = {
     'api-token-created': 'Token generated. Copy it now — it will not be shown again.',
     'api-token-revoked': 'Token revoked.',
+    'api-token-rotated': 'Token rotated. Copy the new value now — it will not be shown again.',
 };
 
 function formatDate(value: string | null): string {
@@ -53,7 +57,7 @@ function formatDate(value: string | null): string {
     }
 }
 
-export default function ApiTokens({ tokens, availableAbilities, newToken, status }: ApiTokensProps) {
+export default function ApiTokens({ tokens, availableAbilities, newToken, status, rotationAgeDays }: ApiTokensProps) {
     const { data, setData, post, processing, errors, reset } = useForm<CreateForm>({
         name: '',
         abilities: [],
@@ -85,6 +89,24 @@ export default function ApiTokens({ tokens, availableAbilities, newToken, status
         });
     };
 
+    const rotate = (token: TokenSummary) => {
+        if (
+            !window.confirm(
+                `Rotate the "${token.name}" token? The old token will be revoked and a new one issued with the same abilities.`,
+            )
+        ) {
+            return;
+        }
+
+        router.post(
+            `/dashboard/settings/api-tokens/${token.id}/rotate`,
+            {},
+            { preserveScroll: true },
+        );
+    };
+
+    const staleCount = tokens.filter((token) => token.needs_rotation).length;
+
     return (
         <AdminLayout title="API tokens">
             <Head title="API tokens" />
@@ -101,6 +123,14 @@ export default function ApiTokens({ tokens, availableAbilities, newToken, status
 
                 {status && STATUS_MESSAGES[status] ? (
                     <Alert color="success">{STATUS_MESSAGES[status]}</Alert>
+                ) : null}
+
+                {staleCount > 0 ? (
+                    <Alert color="warning" data-testid="stale-token-warning">
+                        {staleCount === 1
+                            ? `1 token is older than ${rotationAgeDays} days. Rotate it to stay within policy.`
+                            : `${staleCount} tokens are older than ${rotationAgeDays} days. Rotate them to stay within policy.`}
+                    </Alert>
                 ) : null}
 
                 {newToken ? (
@@ -196,9 +226,29 @@ export default function ApiTokens({ tokens, availableAbilities, newToken, status
                                     </thead>
                                     <tbody>
                                         {tokens.map((token) => (
-                                            <tr key={token.id} className="border-t border-border">
+                                            <tr
+                                                key={token.id}
+                                                className="border-t border-border"
+                                                data-testid={`token-row-${token.id}`}
+                                                data-needs-rotation={token.needs_rotation ? 'true' : 'false'}
+                                            >
                                                 <td className="py-3 pr-4 font-medium text-text">
-                                                    {token.name}
+                                                    <div className="flex items-center gap-2">
+                                                        <span>{token.name}</span>
+                                                        {token.needs_rotation ? (
+                                                            <span
+                                                                className="rounded-box bg-warning/15 px-2 py-0.5 text-xsmall font-semibold text-warning"
+                                                                data-testid="rotation-badge"
+                                                                title={
+                                                                    token.age_days !== null
+                                                                        ? `Token is ${token.age_days} days old`
+                                                                        : undefined
+                                                                }
+                                                            >
+                                                                Rotate
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
                                                 </td>
                                                 <td className="py-3 pr-4 text-text-muted">
                                                     {token.abilities.length > 0
@@ -212,13 +262,24 @@ export default function ApiTokens({ tokens, availableAbilities, newToken, status
                                                     {formatDate(token.created_at)}
                                                 </td>
                                                 <td className="py-3 text-right">
-                                                    <Button
-                                                        type="button"
-                                                        color="danger"
-                                                        onClick={() => revoke(token)}
-                                                    >
-                                                        Revoke
-                                                    </Button>
+                                                    <div className="flex justify-end gap-2">
+                                                        {token.needs_rotation ? (
+                                                            <Button
+                                                                type="button"
+                                                                color="warning"
+                                                                onClick={() => rotate(token)}
+                                                            >
+                                                                Rotate
+                                                            </Button>
+                                                        ) : null}
+                                                        <Button
+                                                            type="button"
+                                                            color="danger"
+                                                            onClick={() => revoke(token)}
+                                                        >
+                                                            Revoke
+                                                        </Button>
+                                                    </div>
                                                 </td>
                                             </tr>
                                         ))}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Analytics\RealtimeController as AnalyticsRealtimeController;
 use App\Http\Controllers\Analytics\SourceController as AnalyticsSourceController;
+use App\Http\Controllers\AuditLogController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Integrations\GoogleController as GoogleIntegrationController;
 use App\Http\Controllers\Settings\ApiTokenController;
@@ -47,6 +48,11 @@ Route::middleware(['auth', 'verified', 'can:view-analytics'])->group(function ()
     // store and Google Analytics for every /dashboard/analytics/* page.
     Route::post('dashboard/analytics/source', [AnalyticsSourceController::class, 'update'])
         ->name('dashboard.analytics.source.update');
+
+    // Audit-log viewer (V2_REFACTOR_PLAN.md §4.3, §9.6 item #46). Reuses
+    // the `can:view-analytics` gate — the same admin-only audience.
+    Route::get('dashboard/audit-log', [AuditLogController::class, 'index'])
+        ->name('dashboard.audit-log');
 });
 
 Route::middleware(['auth'])->group(function () {
@@ -67,6 +73,9 @@ Route::middleware(['auth'])->group(function () {
             Route::delete('api-tokens/{token}', [ApiTokenController::class, 'destroy'])
                 ->whereNumber('token')
                 ->name('api-tokens.destroy');
+            Route::post('api-tokens/{token}/rotate', [ApiTokenController::class, 'rotate'])
+                ->whereNumber('token')
+                ->name('api-tokens.rotate');
         });
     });
 });

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Role;
+use App\Models\AuditLog;
+use App\Models\User;
+use App\Services\AuditLogger;
+use Inertia\Testing\AssertableInertia;
+use Laravel\Sanctum\Sanctum;
+use Modules\Packages\Changelog;
+use Modules\Packages\Documentation;
+use Modules\Packages\Package;
+
+function actingAsAdmin(): User
+{
+    return User::factory()->create([
+        'role' => Role::Admin,
+        'email_verified_at' => now(),
+    ]);
+}
+
+// -- API write → log round-trips ---------------------------------------------
+
+test('api package create writes an audit-log entry with source=api', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['packages:write']);
+
+    $this->postJson(route('api.v1.packages.store'), [
+        'name' => 'Audit Package',
+        'slug' => 'audit-package',
+        'wiki_url' => 'https://github.com/artisanpack-ui/audit/wiki',
+        'changelog_url' => 'https://github.com/artisanpack-ui/audit/blob/main/CHANGELOG.md',
+        'package_registry' => 'packagist',
+    ])->assertCreated();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log)->not->toBeNull()
+        ->and($log->action)->toBe(AuditLogger::ACTION_CREATED)
+        ->and($log->source)->toBe(AuditLogger::SOURCE_API)
+        ->and($log->resource_type)->toBe(Package::class)
+        ->and($log->user_id)->toBe($user->id)
+        ->and($log->actor_name)->toContain($user->name)
+        ->and($log->changes)->toBeArray()
+        ->and($log->changes['slug'])->toEqual([null, 'audit-package']);
+});
+
+test('api package update writes an audit-log diff of only changed fields', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['packages:write']);
+    $package = Package::factory()->create(['name' => 'Old Name']);
+
+    $this->patchJson(route('api.v1.packages.update', $package), [
+        'name' => 'New Name',
+        'slug' => $package->slug,
+        'wiki_url' => $package->wiki_url,
+        'changelog_url' => $package->changelog_url,
+    ])->assertOk();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->action)->toBe(AuditLogger::ACTION_UPDATED)
+        ->and($log->resource_id)->toBe($package->id)
+        ->and($log->changes)->toHaveKey('name')
+        ->and($log->changes['name'])->toEqual(['Old Name', 'New Name'])
+        ->and($log->changes)->not->toHaveKey('slug');
+});
+
+test('api package delete writes an audit-log entry with the pre-delete snapshot', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['packages:write']);
+    $package = Package::factory()->create();
+
+    $this->deleteJson(route('api.v1.packages.destroy', $package))->assertNoContent();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->action)->toBe(AuditLogger::ACTION_DELETED)
+        ->and($log->resource_id)->toBe($package->id)
+        ->and($log->changes)->toHaveKey('id')
+        ->and($log->changes['id'][0])->toBe($package->id);
+});
+
+test('api documentation create + update + delete each log one entry', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['docs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.documentation.store', $package), [
+        'title' => 'Getting Started',
+        'slug' => 'getting-started',
+        'parent' => 0,
+        'menu_order' => 0,
+        'content' => 'Hello world',
+    ])->assertCreated();
+
+    $doc = Documentation::query()->latest('id')->first();
+
+    $this->patchJson(route('api.v1.documentation.update', $doc), [
+        'title' => 'Updated Title',
+        'slug' => $doc->slug,
+        'parent' => 0,
+        'menu_order' => 0,
+        'content' => $doc->content,
+    ])->assertOk();
+
+    $this->deleteJson(route('api.v1.documentation.destroy', $doc))->assertNoContent();
+
+    $entries = AuditLog::query()
+        ->where('resource_type', Documentation::class)
+        ->orderBy('id')
+        ->get();
+
+    expect($entries)->toHaveCount(3)
+        ->and($entries->pluck('action')->all())->toEqual([
+            AuditLogger::ACTION_CREATED,
+            AuditLogger::ACTION_UPDATED,
+            AuditLogger::ACTION_DELETED,
+        ]);
+});
+
+test('api documentation reorder writes a reordered entry with the order payload', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['docs:write']);
+    $package = Package::factory()->create();
+    $doc = Documentation::factory()->for($package)->create(['menu_order' => 0]);
+
+    $this->postJson(route('api.v1.packages.documentation.reorder', $package), [
+        'items' => [['id' => $doc->id, 'menu_order' => 5]],
+    ])->assertOk();
+
+    $log = AuditLog::query()
+        ->where('resource_type', Package::class)
+        ->where('action', AuditLogger::ACTION_REORDERED)
+        ->latest('id')
+        ->first();
+
+    expect($log)->not->toBeNull()
+        ->and($log->source)->toBe(AuditLogger::SOURCE_API)
+        ->and($log->changes['order'][0])->toEqual(['id' => $doc->id, 'menu_order' => 5]);
+});
+
+test('api changelog create writes an audit-log entry', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['changelogs:write']);
+    $package = Package::factory()->create();
+
+    $this->postJson(route('api.v1.packages.changelogs.store', $package), [
+        'title' => 'v1.0.0',
+        'content' => 'Initial release.',
+    ])->assertCreated();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->action)->toBe(AuditLogger::ACTION_CREATED)
+        ->and($log->resource_type)->toBe(Changelog::class);
+});
+
+test('api actor name includes the token name', function () {
+    $user = User::factory()->create();
+    $newToken = $user->createToken('artisanpackui.dev prod', ['packages:write']);
+
+    $this->withHeader('Authorization', 'Bearer '.$newToken->plainTextToken)
+        ->postJson(route('api.v1.packages.store'), [
+            'name' => 'Named',
+            'slug' => 'named',
+            'wiki_url' => 'https://github.com/artisanpack-ui/named/wiki',
+            'changelog_url' => 'https://github.com/artisanpack-ui/named/blob/main/CHANGELOG.md',
+            'package_registry' => 'packagist',
+        ])->assertCreated();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->actor_name)->toContain('artisanpackui.dev prod');
+});
+
+// -- Web write → log round-trips ---------------------------------------------
+
+test('web package create writes an audit-log entry with source=web', function () {
+    $admin = actingAsAdmin();
+
+    $this->actingAs($admin)->post(route('dashboard.packages.store'), [
+        'name' => 'Web Package',
+        'slug' => 'web-package',
+        'wiki_url' => 'https://github.com/artisanpack-ui/web/wiki',
+        'changelog_url' => 'https://github.com/artisanpack-ui/web/blob/main/CHANGELOG.md',
+        'package_registry' => 'packagist',
+    ])->assertRedirect();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->source)->toBe(AuditLogger::SOURCE_WEB)
+        ->and($log->action)->toBe(AuditLogger::ACTION_CREATED)
+        ->and($log->user_id)->toBe($admin->id);
+});
+
+test('web package delete writes an audit-log entry with source=web', function () {
+    $admin = actingAsAdmin();
+    $package = Package::factory()->create();
+
+    $this->actingAs($admin)->delete(route('dashboard.packages.destroy', $package))
+        ->assertRedirect();
+
+    $log = AuditLog::query()->latest('id')->first();
+
+    expect($log->source)->toBe(AuditLogger::SOURCE_WEB)
+        ->and($log->action)->toBe(AuditLogger::ACTION_DELETED)
+        ->and($log->resource_id)->toBe($package->id);
+});
+
+// -- Viewer ------------------------------------------------------------------
+
+test('the audit-log viewer requires admin', function () {
+    $editor = User::factory()->create([
+        'role' => Role::Editor,
+        'email_verified_at' => now(),
+    ]);
+
+    $this->actingAs($editor)->get(route('dashboard.audit-log'))->assertForbidden();
+});
+
+test('the audit-log viewer renders recent entries newest-first', function () {
+    $admin = actingAsAdmin();
+
+    AuditLog::create([
+        'user_id' => $admin->id,
+        'actor_name' => 'older',
+        'source' => 'web',
+        'resource_type' => Package::class,
+        'resource_id' => 1,
+        'action' => 'created',
+        'changes' => null,
+        'ip_address' => '127.0.0.1',
+        'created_at' => now()->subHour(),
+    ]);
+
+    AuditLog::create([
+        'user_id' => $admin->id,
+        'actor_name' => 'newer',
+        'source' => 'api',
+        'resource_type' => Documentation::class,
+        'resource_id' => 2,
+        'action' => 'updated',
+        'changes' => ['title' => ['a', 'b']],
+        'ip_address' => '10.0.0.1',
+        'created_at' => now(),
+    ]);
+
+    $response = $this->actingAs($admin)->get(route('dashboard.audit-log'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Dashboard/AuditLog')
+        ->has('entries.data', 2)
+        ->where('entries.data.0.actor_name', 'newer')
+        ->where('entries.data.1.actor_name', 'older')
+        ->where('entries.data.0.resource_label', 'documentation')
+    );
+});
+
+test('the audit-log viewer filters by resource', function () {
+    $admin = actingAsAdmin();
+
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'a', 'source' => 'web',
+        'resource_type' => Package::class, 'resource_id' => 1,
+        'action' => 'created', 'created_at' => now(),
+    ]);
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'b', 'source' => 'web',
+        'resource_type' => Documentation::class, 'resource_id' => 1,
+        'action' => 'created', 'created_at' => now(),
+    ]);
+
+    $response = $this->actingAs($admin)->get(route('dashboard.audit-log', ['resource' => 'package']));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Dashboard/AuditLog')
+        ->has('entries.data', 1)
+        ->where('entries.data.0.resource_type', Package::class)
+    );
+});
+
+test('the audit-log viewer filters by source', function () {
+    $admin = actingAsAdmin();
+
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'w', 'source' => 'web',
+        'resource_type' => Package::class, 'resource_id' => 1,
+        'action' => 'created', 'created_at' => now(),
+    ]);
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'a', 'source' => 'api',
+        'resource_type' => Package::class, 'resource_id' => 2,
+        'action' => 'created', 'created_at' => now(),
+    ]);
+
+    $response = $this->actingAs($admin)->get(route('dashboard.audit-log', ['source' => 'api']));
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->has('entries.data', 1)
+        ->where('entries.data.0.source', 'api')
+    );
+});
+
+test('the audit-log viewer filters by actor and date range', function () {
+    $admin = actingAsAdmin();
+
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'Alice', 'source' => 'web',
+        'resource_type' => Package::class, 'resource_id' => 1,
+        'action' => 'created', 'created_at' => now()->subDays(10),
+    ]);
+    AuditLog::create([
+        'user_id' => $admin->id, 'actor_name' => 'Bob', 'source' => 'web',
+        'resource_type' => Package::class, 'resource_id' => 2,
+        'action' => 'created', 'created_at' => now(),
+    ]);
+
+    $this->actingAs($admin)
+        ->get(route('dashboard.audit-log', ['actor' => 'Ali']))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.actor_name', 'Alice')
+        );
+
+    $this->actingAs($admin)
+        ->get(route('dashboard.audit-log', [
+            'from' => now()->subDays(2)->toDateString(),
+        ]))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.actor_name', 'Bob')
+        );
+});

--- a/tests/Feature/Settings/ApiTokensTest.php
+++ b/tests/Feature/Settings/ApiTokensTest.php
@@ -155,3 +155,68 @@ it('does not let a user revoke another user\'s token', function () {
     $response->assertNotFound();
     expect($owner->refresh()->tokens()->count())->toBe(1);
 });
+
+it('flags tokens older than 90 days for rotation', function () {
+    $user = User::factory()->create();
+    confirmPasswordForApiTokens();
+
+    $stale = $user->createToken('stale', [TokenAbility::PackagesRead->value])->accessToken;
+    $stale->forceFill(['created_at' => now()->subDays(120)])->save();
+
+    $user->createToken('fresh', [TokenAbility::PackagesRead->value]);
+
+    $response = $this->actingAs($user)->get(route('dashboard.settings.api-tokens'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Settings/ApiTokens')
+        ->where('rotationAgeDays', 90)
+        ->has('tokens', 2)
+        ->where('tokens', fn ($tokens) => collect($tokens)
+            ->firstWhere('name', 'stale')['needs_rotation'] === true
+            && collect($tokens)->firstWhere('name', 'fresh')['needs_rotation'] === false)
+    );
+});
+
+it('rotates a stale token: revokes the old one, mints a new one with the same abilities', function () {
+    $user = User::factory()->create();
+    confirmPasswordForApiTokens();
+
+    $original = $user->createToken('artisanpackui.dev', [
+        TokenAbility::PackagesRead->value,
+        TokenAbility::DocsWrite->value,
+    ])->accessToken;
+    $original->forceFill(['created_at' => now()->subDays(120)])->save();
+
+    $response = $this->actingAs($user)
+        ->from(route('dashboard.settings.api-tokens'))
+        ->post(route('dashboard.settings.api-tokens.rotate', ['token' => $original->id]));
+
+    $response->assertRedirect(route('dashboard.settings.api-tokens'));
+    $response->assertSessionHas('status', 'api-token-rotated');
+
+    $flashed = session('new_api_token');
+    expect($flashed['name'])->toBe('artisanpackui.dev')
+        ->and($flashed['plain_text'])->toBeString()
+        ->and($flashed['plain_text'])->not->toBe('');
+
+    $tokens = $user->refresh()->tokens()->get();
+    expect($tokens)->toHaveCount(1)
+        ->and($tokens->first()->id)->not->toBe($original->id)
+        ->and($tokens->first()->name)->toBe('artisanpackui.dev')
+        ->and(array_values((array) $tokens->first()->abilities))
+        ->toEqual(['packages:read', 'docs:write']);
+});
+
+it('does not let a user rotate another user\'s token', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    confirmPasswordForApiTokens();
+    $token = $owner->createToken('owned', [TokenAbility::PackagesRead->value])->accessToken;
+
+    $response = $this->actingAs($intruder)
+        ->post(route('dashboard.settings.api-tokens.rotate', ['token' => $token->id]));
+
+    $response->assertNotFound();
+    expect($owner->refresh()->tokens()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Bundles three v3.0 plan items (V2_REFACTOR_PLAN.md §9.6 items #45, #46, #47) into a single branch.

## Related Issue

Closes #109
Closes #110
Closes #111

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

**#109 — `docs/API.md` + Bruno collection**
- Full spec for `/api/v1` (packages, documentation, changelogs): abilities, payloads, error envelope, rate limiting, audit-log note.
- Bruno collection under `docs/api/bruno/` with request per endpoint and a `local` environment.

**#110 — Audit log**
- `audit_log` migration + `AuditLog` model (immutable rows, no `updated_at`).
- `AuditLogger` service: resolves actor (with token name on API writes), source (`web`/`api`), IP; stores diff of changed attributes only.
- Wired into `PackageController` / `DocumentationController` / `ChangelogController` (both `Api/V1/*` and admin web) and `DocumentationReorderController` for create / update / delete / reorder.
- Admin-only `/dashboard/audit-log` Inertia viewer with filters: resource, actor, source, from/to.
- Sidebar entry in `AdminLayout` (admin role only).

**#111 — PAT rotation reminder**
- `/dashboard/settings/api-tokens` computes `needs_rotation` and `age_days`; tokens ≥ 90 days show a warning banner + per-row "Rotate" pill and button.
- New `POST /dashboard/settings/api-tokens/{token}/rotate` (inside the `password.confirm` group). Deletes the old token and issues a fresh one with the same name + allow-listed abilities. Wrapped in `DB::transaction()` so a failed re-issue rolls the delete back.

## Testing

- [x] Tests added or updated (14 new audit-log tests + 4 new rotation tests)
- [x] Manually tested locally (create/update/delete on packages, backdated token rotation, Bruno request into audit log)

Full suite: **525 passed, 2639 assertions**.

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [x] Documentation updated (`docs/API.md` + Bruno collection are the docs deliverable for #109)
- [ ] Changelog updated (not applicable — release/3.0 branch)

## Security notes

Reviewed the diff with a security focus before opening:

- Rotate action scopes tokens by `$user->tokens()->whereKey(...)` (no cross-user reach), sits inside `password.confirm`, and re-filters abilities through the `TokenAbility` allow-list (a since-removed ability cannot survive a rotation).
- `/dashboard/audit-log` gated by `can:view-analytics` (admin only); PII (emails, IPs) never exposed to editors.
- All filter inputs go through `$request->validate()`; `actor` uses a parameter-bound `LIKE`.

Follow-up items (not blocking, filed as future improvements):

- Wrap resource-write + audit-write in one transaction so a failed audit INSERT can roll back the resource change.
- Add an `audit:purge-old` scheduled command; consider truncating large `content` diffs to a preview.
- Migrate `AuditLogController::RESOURCE_MAP` FQCNs to an Eloquent morph map so model renames stay filterable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin Audit Log dashboard with filtering, expandable change details, and pagination.
  * Package, documentation, changelog, and reorder actions now create audit records.
  * Added API token age indicators and token rotation with ability preservation.
  * Added API documentation and Bruno request examples for the v1 API.

* **Documentation**
  * Documented authentication, permissions, endpoints, errors, audit logging, and local API testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->