### PR TITLE
docs: add 3.0.0 CHANGELOG entry (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.0.0] - Unreleased
+
+### Added
+- Inertia.js v2 + React 19 + TypeScript frontend, replacing the Livewire/Volt/Flux stack
+- Inertia SSR (Node process alongside PHP-FPM) for first-paint parity with server-rendered pages
+- ArtisanPack UI design system adoption: dark-first theme, Poppins + Space Mono, neon triad on space-black grounds, `.ap-box` / gradient / glow language
+- Design tokens as CSS custom properties (`resources/css/tokens/*.css`) wired into Tailwind v4 `@theme` so utilities like `bg-base`, `text-secondary`, `shadow-glow-gradient`, `rounded-box` map to AP-UI tokens
+- Laravel Fortify for web auth: email verification, 2FA (with password + OTP confirmation), password reset (registration disabled)
+- Laravel Sanctum-guarded JSON API under `/api/v1` for `artisanpackui.dev` and other consumers, with per-token ability scopes (`packages:read`, `packages:write`, `docs:read`, `docs:write`, `changelogs:read`, `changelogs:write`)
+- Personal access token management at `/settings/api-tokens` with abilities checklist, `last_used_at`, revoke, and a 90-day rotation warning
+- `php artisan artisanpack:issue-token` command to mint the first API token before the UI is available
+- CORS + rate limiting scoped to the API surface
+- Audit log for every write on both the web admin and the API (`audit_log` table capturing actor, source, resource type + id, action, JSON diff, IP, timestamp), viewable at `/dashboard/audit-log` with filters by resource, actor, and source
+- React `SearchOverlay` (⌘K) replacing the Livewire spotlight
+- Designed 404 and 500 error pages
+- v1 API documentation
+
+### Changed
+- Upgraded Laravel 12 → 13 and PHP baseline to 8.4
+- Redesigned every public and admin surface against the new design system while preserving §4.1 URL structure byte-identically
+- Docs viewer redesigned to the "Precision rail" layout: sticky top bar (logo + ⌘K + theme + social) with a 2px `--grad-neon` hairline, then a `290px | 1fr | 264px` 3-column grid (sidebar tree · content · TOC)
+- Docs orderer ported from Livewire to a React nested drag-and-drop implementation (1:1 UX parity), reusing the same reorder endpoint that's exposed on the API
+- Authentication and settings routes rewired to Fortify + Inertia pages; existing session/logout flows preserved
+
+### Removed
+- Livewire stack: `livewire/livewire`, `livewire/volt`, `livewire/flux`, `mhmiton/laravel-modules-livewire`, `artisanpack-ui/livewire-ui-components`
+- npm: `@artisanpack-ui/livewire-drag-and-drop`, `daisyui`
+- User registration (Fortify feature disabled — accounts are provisioned by an admin)
+
 ## [2.0.0] - 2026-03-28
 
 ### Added


### PR DESCRIPTION
## Summary

Adds the 3.0.0 entry to \`CHANGELOG.md\`, summarizing the redesign, Livewire→Inertia+React stack change, Sanctum-guarded API, audit log, Fortify auth, and design-system adoption.

Dated as **Unreleased** — the final date lands with the v3.0.0 tag in #117.

## Related Issue

Closes #115

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

- New \`## [3.0.0] - Unreleased\` section with Added / Changed / Removed subsections following the existing Keep-a-Changelog format used by the 2.0.0 entry.

## Testing

- [ ] Tests added or updated (docs-only change; not applicable)
- [x] Manually reviewed the rendered markdown

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes (no PHP touched)
- [x] Tests pass (no code touched)
- [x] Documentation updated
- [x] Changelog updated