### PR TITLE
fix: restore daisyUI to unbreak admin styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 - Livewire stack: `livewire/livewire`, `livewire/volt`, `livewire/flux`, `mhmiton/laravel-modules-livewire`, `artisanpack-ui/livewire-ui-components`
-- npm: `@artisanpack-ui/livewire-drag-and-drop`, `daisyui`
+- npm: `@artisanpack-ui/livewire-drag-and-drop`
 - User registration (Fortify feature disabled — accounts are provisioned by an admin)
 
 ## [2.0.0] - 2026-03-28

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
+        "daisyui": "^5.7.4",
         "eslint": "^9.39.5",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
@@ -3275,6 +3276,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/daisyui": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.7.4.tgz",
+      "integrity": "sha512-zKzFIwvEvn2QvE1TbUUtDnYFOqWoxeZh+j4QXfhkZKYAT++pO2ijyT9rkFm0GIPDWR1/oo9hHZzd96AsTK0iZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "daisyui": "^5.7.4",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -12,6 +12,10 @@
 @source '../../Modules/*/resources/js/**/*.tsx';
 @source '../../node_modules/@artisanpack-ui/react/dist/**/*.mjs';
 
+@plugin "daisyui" {
+    themes: light --default, dark --prefersdark;
+}
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* =====================================================================


### PR DESCRIPTION
## Summary

Fixes the admin styling regression introduced by #114. The daisyUI plugin was removed as part of the dead-dependency cleanup, but the Inertia admin components (and the \`@artisanpack-ui/react\` library they consume) still rely on daisyUI utility classes — \`.btn\`, \`.btn-primary\`, \`.btn-ghost\`, \`.btn-secondary\`, \`.btn-sm\`, \`.dropdown\`, \`.menu\`, etc. — so the whole \`/dashboard\` tree lost its dropdowns, buttons, and pagination styling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- \`npm install --save-dev daisyui\` (^5.7.4)
- Re-added \`@plugin "daisyui" { themes: light --default, dark --prefersdark; }\` to \`resources/css/app.css\`
- Corrected the 3.0.0 CHANGELOG \`### Removed\` line to drop daisyUI — retiring it is a future refactor blocked on the React admin components dropping the utility-class dependency

Not touched:
- The 6 module CSS stubs left behind by #114 stay stubs — they styled Livewire-era views that no longer exist.

## Testing

- [ ] Tests added or updated (no test surface for the styling — it's a visual regression caught by the maintainer)
- [x] Manually tested locally
- [x] \`npm run build\` (client + SSR) → passed
- [x] \`php -d memory_limit=1G vendor/bin/pest\` → **549 tests / 2845 assertions passing**

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes (no PHP touched)
- [x] Tests pass
- [x] Documentation updated (CHANGELOG corrected)
- [x] Changelog updated

## Screenshots

_Before this fix: the admin area rendered without dropdowns, without styled buttons, and with plain-text pagination — see the regression report on the branch source._