### PR TITLE
fix: make ApexCharts SSR-safe under Inertia

### DIFF
--- a/resources/js/components/LazyApexChart.tsx
+++ b/resources/js/components/LazyApexChart.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import type { ComponentType } from 'react';
+import type { ApexOptions } from 'apexcharts';
+
+/**
+ * Client-only wrapper around `react-apexcharts`. ApexCharts touches
+ * `window` / `document` / `getComputedStyle` at module load time, which
+ * crashes the Inertia SSR bundle. Deferring the import to `useEffect`
+ * keeps the component tree renderable on the server (returns null,
+ * matching the pre-hydration DOM) and only pulls the chart library in
+ * once we're safely in the browser.
+ */
+
+export interface LazyApexChartProps {
+    type: NonNullable<ApexOptions['chart']>['type'];
+    options: ApexOptions;
+    series: unknown;
+    height?: number | string;
+    width?: number | string;
+}
+
+type ReactApexChartComponent = ComponentType<LazyApexChartProps>;
+
+export function LazyApexChart(props: LazyApexChartProps) {
+    const [Chart, setChart] = useState<ReactApexChartComponent | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        import('react-apexcharts').then((mod) => {
+            if (!cancelled) {
+                setChart(() => mod.default as ReactApexChartComponent);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (!Chart) {
+        return null;
+    }
+
+    return <Chart {...props} />;
+}

--- a/resources/js/pages/Analytics/components/PageViewsChart.tsx
+++ b/resources/js/pages/Analytics/components/PageViewsChart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
 import type { ApexOptions } from 'apexcharts';
+import { LazyApexChart } from '@/components/LazyApexChart';
 
 export interface ChartPoint {
     date: string;
@@ -111,7 +111,7 @@ export function PageViewsChart( { data, height = 300 }: PageViewsChartProps ) {
 
     return (
         <div className="min-h-[300px]">
-            <Chart type="area" options={options} series={series} height={height} />
+            <LazyApexChart type="area" options={options} series={series} height={height} />
         </div>
     );
 }

--- a/resources/js/pages/Dashboard/components/DashChart.tsx
+++ b/resources/js/pages/Dashboard/components/DashChart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import ReactApexChart from 'react-apexcharts';
 import type { ApexOptions } from 'apexcharts';
+import { LazyApexChart } from '@/components/LazyApexChart';
 
 /**
  * Local Chart wrapper mirroring the small subset of the
@@ -8,8 +8,9 @@ import type { ApexOptions } from 'apexcharts';
  * component's pre-built ESM chunk imports `react-apexcharts` in a way
  * that trips ESM/CJS default-interop under Vite ("Element type is
  * invalid… Check the render method of `Chart`."); the local wrapper
- * imports `react-apexcharts` directly the same way the analytics
- * dashboard does, which Vite handles correctly.
+ * routes through `LazyApexChart`, which defers the `react-apexcharts`
+ * import to `useEffect` so the SSR bundle can compile the tree without
+ * pulling in browser-only ApexCharts globals.
  */
 export type DashChartType = 'bar' | 'line' | 'area' | 'donut' | 'pie';
 
@@ -217,7 +218,7 @@ export function DashChart({
 
     return (
         <div className="min-h-[200px]">
-            <ReactApexChart
+            <LazyApexChart
                 type={type}
                 options={options}
                 series={apexSeries as never}

--- a/resources/js/stubs/ApexChartsSsrStub.tsx
+++ b/resources/js/stubs/ApexChartsSsrStub.tsx
@@ -1,0 +1,18 @@
+/**
+ * SSR-only stub for `apexcharts` and `react-apexcharts`.
+ *
+ * The `apexcharts` package touches `window`, `document`, and
+ * `getComputedStyle` at module scope, which crashes the Inertia SSR
+ * Node process the moment any component in the imported tree references
+ * it — including transitively via `@artisanpack-ui/react`'s barrel,
+ * which unconditionally pulls its own `Chart` chunk. `vite.config.js`
+ * aliases both packages to this file when `isSsrBuild` is true; the
+ * client build resolves the real packages as normal.
+ */
+
+import type { ComponentType } from 'react';
+
+const ChartStub: ComponentType<Record<string, unknown>> = () => null;
+
+export default ChartStub;
+export const ApexOptions = {};

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ const moduleAssets = globSync(
     'Modules/*/resources/assets/{js,css,scss}/*.{js,scss,css}',
 );
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
     // In dev, Vite serves resources/css/app.css from its own origin
     // (https://<host>:5173), so `url('/fonts/…')` inside that CSS resolves
     // against Vite — not Laravel. Point publicDir at Laravel's public/ so
@@ -36,6 +36,28 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+            // Stub `apexcharts` and `react-apexcharts` in the SSR bundle
+            // only. Both touch `window` / `document` / `getComputedStyle`
+            // at module load and crash Node the moment ssr.js starts —
+            // and `@artisanpack-ui/react`'s barrel pulls them in
+            // transitively via its Chart chunk, so even importing
+            // `ThemeToggle` from the barrel is enough to trip it. The
+            // stub renders `null`; on the client the real packages
+            // resolve as normal.
+            ...(isSsrBuild && {
+                'react-apexcharts': fileURLToPath(
+                    new URL(
+                        './resources/js/stubs/ApexChartsSsrStub.tsx',
+                        import.meta.url,
+                    ),
+                ),
+                apexcharts: fileURLToPath(
+                    new URL(
+                        './resources/js/stubs/ApexChartsSsrStub.tsx',
+                        import.meta.url,
+                    ),
+                ),
+            }),
             // The vendor ships both `tracker.js` (the core IIFE that
             // installs `window.ArtisanPackAnalytics` and auto-inits on
             // DOMContentLoaded) and `analytics-api.js` (a thin
@@ -71,4 +93,14 @@ export default defineConfig({
             ),
         },
     },
-});
+    // Force Vite to bundle these into the SSR output rather than
+    // externalizing them (Node's require bypasses `resolve.alias`).
+    // `@artisanpack-ui/react` has to be here too — Vite would otherwise
+    // externalize it, letting Node load its barrel and transitively
+    // pull `react-apexcharts` before our alias ever gets a chance.
+    // Bundling forces every import through Vite's resolver so the
+    // SSR stub above wins.
+    ssr: {
+        noExternal: [/^@artisanpack-ui\/react($|\/)/, 'react-apexcharts', 'apexcharts'],
+    },
+}));


### PR DESCRIPTION
## Summary

Unblocks the Inertia SSR daemon. \`php artisan inertia:start-ssr\` crashed at boot because ApexCharts touches \`window\`/\`document\`/\`getComputedStyle\` at module scope, and even though we never render a chart during SSR, \`@artisanpack-ui/react\`'s barrel unconditionally pulls its Chart chunk, which transitively imports \`apexcharts\` into the Node process.

## Type of Change

- [x] Bug fix

## Root cause

The chain that dragged apex into Node:

1. Any file (\`AppShell\`, \`AdminLayout\`, etc.) imports \`ThemeToggle\`, \`useTheme\`, or \`ThemeProvider\` from the \`@artisanpack-ui/react\` barrel.
2. AP-UI's \`index.mjs\` unconditionally re-exports its \`Chart\` chunk (\`chunk-BVB7QFIE.mjs\`) — no \`sideEffects: false\` in its package.json, so tree-shaking can't drop it.
3. That chunk statically imports \`react-apexcharts\`, which imports \`apexcharts\`, which runs browser-only code at module load.
4. Vite's default SSR build externalizes vendor deps, so Node's \`require\` — not our aliases — resolves \`@artisanpack-ui/react\`, hitting steps 2-3 the moment ssr.js boots.

## Changes

- **\`resources/js/stubs/ApexChartsSsrStub.tsx\`** — null-rendering component. Both \`apexcharts\` and \`react-apexcharts\` alias to this in SSR builds.
- **\`vite.config.js\`** — switched to functional config to read \`isSsrBuild\`. SSR-only \`resolve.alias\` for both packages. Added \`ssr.noExternal\` for them **and** \`/^@artisanpack-ui\\/react/\` — forcing the AP-UI barrel through Vite's resolver is what lets the alias actually intercept.
- **\`resources/js/components/LazyApexChart.tsx\`** — defensive client-side wrapper. Defers \`react-apexcharts\` to \`useEffect\` so future imports outside the SSR-stubbed context can't reintroduce the issue.
- **\`DashChart.tsx\` + \`PageViewsChart.tsx\`** — swap direct \`react-apexcharts\` imports for the \`LazyApexChart\` wrapper.

## Testing

- [x] \`npm run build\` (client + SSR) — clean
- [x] SSR bundle boots (\`node bootstrap/ssr/ssr.js\`) and returns HTTP 200 for a POST /render on \`Dashboard/Index\`
- [x] Client bundle: real apex still shipped (\`grep -c apexcharts public/build/assets/*.js\` > 0), zero refs to the SSR stub
- [x] \`vendor/bin/pint --dirty\` — passed
- [x] \`php -d memory_limit=1G vendor/bin/pest\` — **549 tests / 2845 assertions passing**

## Deployment note

After this merges + deploys, the Inertia SSR Background Process should stay \`RUNNING\` in Forge instead of crash-looping. Verify with:

\`\`\`bash
ssh forge@134.122.19.14 "sudo supervisorctl status | grep -i ssr"
curl -s https://docs.artisanpackui.dev/ | grep -c 'data-page'  # want: 1
\`\`\`

## Checklist

- [x] Code follows project conventions
- [x] Pint formatting passes
- [x] Tests pass
- [ ] Documentation updated (not applicable)
- [ ] Changelog updated (not applicable — infra fix)