### PR TITLE
fix: a11y + render-blocking asset hits from Lighthouse dry-run (#113)

### DIFF
--- a/Modules/Core/app/Services/TableOfContentsService.php
+++ b/Modules/Core/app/Services/TableOfContentsService.php
@@ -18,6 +18,8 @@ class TableOfContentsService
             $content = $this->convertMarkdown($content);
         }
 
+        $content = $this->normalizeAccessibility($content);
+
         // Extract and add IDs to headings
         $headings = [];
         $content = $this->addIdsToHeadings($content, $headings);
@@ -26,6 +28,21 @@ class TableOfContentsService
             'headings' => $headings,
             'content' => $content,
         ];
+    }
+
+    /**
+     * The Lexical editor emits `<li role="presentation">` on list items,
+     * which axe flags as `list` (a UL/OL may only contain LI elements
+     * without a presentation role). Strip the attribute on render so
+     * downstream a11y audits stay green.
+     */
+    protected function normalizeAccessibility(string $content): string
+    {
+        return preg_replace(
+            '/(<li\b[^>]*?)\s+role=(["\'])presentation\2/i',
+            '$1',
+            $content
+        ) ?? $content;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@artisanpack-ui/privacy": "file:vendor/artisanpack-ui/privacy",
         "@artisanpack-ui/react": "^1.0.1",
         "@artisanpack-ui/tokens": "^1.0.1",
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@inertiajs/react": "^2.3.27",
         "@tiptap/extension-link": "^3.29.0",
         "@tiptap/pm": "^3.29.0",
@@ -1053,6 +1054,15 @@
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@artisanpack-ui/privacy": "file:vendor/artisanpack-ui/privacy",
     "@artisanpack-ui/react": "^1.0.1",
     "@artisanpack-ui/tokens": "^1.0.1",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@inertiajs/react": "^2.3.27",
     "@tiptap/extension-link": "^3.29.0",
     "@tiptap/pm": "^3.29.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import '@artisanpack-ui/tokens/css';
+@import '@fortawesome/fontawesome-free/css/all.min.css';
 
 @import './tokens/fonts.css';
 @import './tokens/colors.css';

--- a/resources/js/layouts/DocsLayout.tsx
+++ b/resources/js/layouts/DocsLayout.tsx
@@ -116,13 +116,13 @@ export function DocsLayout({ children, sidebar, toc }: DocsLayoutProps) {
                         type="button"
                         onClick={openSearch}
                         className="hidden h-[42px] flex-1 items-center gap-2.5 rounded-[10px] border border-border-subtle bg-surface-2 px-4 text-left text-small transition hover:border-border md:flex"
-                        aria-label="Open search (⌘K)"
+                        aria-label="Search the docs"
                     >
                         <i
-                            className="fa-solid fa-magnifying-glass text-[14px] text-text-subtle"
+                            className="fa-solid fa-magnifying-glass text-[14px] text-text-muted"
                             aria-hidden
                         />
-                        <span className="flex-1 text-text-subtle">Search the docs</span>
+                        <span className="flex-1 text-text-muted">Search the docs</span>
                         <span className="ml-auto inline-flex gap-1">
                             <kbd className="rounded-[5px] border border-border-subtle bg-surface px-[7px] py-[2px] font-mono text-[11px] text-text-muted">
                                 ⌘

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -26,8 +26,6 @@
         <link rel="preload" as="font" type="font/woff2" href="/fonts/poppins/poppins-400-latin.woff2" crossorigin>
         <link rel="preload" as="font" type="font/woff2" href="/fonts/poppins/poppins-500-latin.woff2" crossorigin>
 
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-
         @include('partials.theme-boot')
 
         @viteReactRefresh

--- a/tests/Feature/SearchOverlayTest.php
+++ b/tests/Feature/SearchOverlayTest.php
@@ -35,7 +35,7 @@ it('mounts the SearchOverlay inside DocsLayout and wires the header button to it
         ->toContain('useSearchOverlay()')
         ->toContain('<SearchOverlay')
         ->toContain('onClick={openSearch}')
-        ->toContain('aria-label="Open search (⌘K)"');
+        ->toContain('aria-label="Search the docs"');
 });
 
 it('registers the /search route pointing at SearchController@search', function () {

--- a/tests/Feature/Services/TableOfContentsServiceTest.php
+++ b/tests/Feature/Services/TableOfContentsServiceTest.php
@@ -102,3 +102,31 @@ test('builds empty nested structure for no headings', function () {
 
     expect($nested)->toBeEmpty();
 });
+
+test('strips role="presentation" from li elements emitted by Lexical', function () {
+    $service = new TableOfContentsService;
+
+    $html = '<ul>'
+        .'<li dir="ltr" role="presentation">First</li>'
+        .'<li role="presentation" dir="ltr">Second</li>'
+        .'<li>Kept as-is</li>'
+        .'</ul>';
+
+    $result = $service->process($html, isMarkdown: false);
+
+    expect($result['content'])->not->toContain('role="presentation"')
+        ->and($result['content'])->toContain('<li dir="ltr">First</li>')
+        ->and($result['content'])->toContain('<li dir="ltr">Second</li>')
+        ->and($result['content'])->toContain('<li>Kept as-is</li>');
+});
+
+test('preserves role="presentation" on non-li elements', function () {
+    $service = new TableOfContentsService;
+
+    $html = '<div role="presentation">Wrapper</div><table role="presentation"><tr><td>x</td></tr></table>';
+
+    $result = $service->process($html, isMarkdown: false);
+
+    expect($result['content'])->toContain('<div role="presentation">')
+        ->and($result['content'])->toContain('<table role="presentation">');
+});


### PR DESCRIPTION
## Summary

- SSR staging dry-run against `docs.artisanpackui.dev` produced the following Lighthouse scores (mobile & desktop):

  | Page | Strategy | Perf | A11y | BP | SEO |
  |------|----------|------|------|----|----|
  | `/` | desktop | **85** | **93** | 96 | 100 |
  | `/` | mobile | **92** | **92** | 96 | 100 |
  | `/documentation/accessibility/api-reference` | desktop | 96 | 96 | 96 | 100 |
  | `/documentation/accessibility/api-reference` | mobile | **93** | 96 | 96 | 100 |

  The docs page passes desktop cleanly; home fails the ≥95 gate on Perf and A11y.

- This PR fixes the four contained issues surfaced by the audit:
  - **`label-content-name-mismatch`** — `resources/js/layouts/DocsLayout.tsx:119` had `aria-label="Open search (⌘K)"` on a button whose visible text was "Search the docs". Changed to `aria-label="Search the docs"`.
  - **`color-contrast`** — same button's placeholder used `text-text-subtle` (#6B7280) on `bg-surface-2` (#111827) = 3.66:1. Switched the span + icon to `text-text-muted` (#9CA3AF) = 6.9:1.
  - **`list`** — Lexical emits `<li dir="ltr" role="presentation">` and axe flags UL/OL children that carry a presentation role. Added `TableOfContentsService::normalizeAccessibility()` that strips `role="presentation"` from `<li>` on the render path both `HomePageController` and `PageViewerController` already funnel through.
  - **`render-blocking-resources`** — Font Awesome loaded from `cdnjs.cloudflare.com` in `resources/views/app.blade.php`. Self-hosted via `@fortawesome/fontawesome-free` imported in `resources/css/app.css`; Vite bundles + hashes the CSS and WOFF2 assets on our origin.

- **Not fixed here:** TTFB is ~2s on the SSR round-trip on both pages (measured three times each). Doesn't fit inside a bugfix PR — see the follow-up section below.

Closes #113.

## Follow-up (not in this PR)

- **Perf: reduce SSR round-trip TTFB below 500ms.** Even with everything above, home LCP starts from ~2s of pure TTFB, so Perf may not clear 95 on desktop until the SSR round-trip is faster. Options: full-page anon cache in front of SSR, tune the Forge box, or trim the data `HandleInertiaRequests` shares on every request. Worth filing as a separate ticket after this merges and we re-measure.

## Test plan

- [x] `php artisan test --filter=TableOfContents` — 10/10 pass (2 new tests for the normalizer, both green; verifies `<li role="presentation">` stripped and other elements keep the role).
- [x] `php artisan test --filter="PageViewer|HomePage|TableOfContents"` — 52/52 pass, no regressions.
- [x] `vendor/bin/pint --dirty` — passes.
- [x] `npm run build` — client + SSR bundles build cleanly, FA CSS and WOFF2 assets appear under `public/build/assets/`.
- [ ] After deploy: re-run Lighthouse against home + docs, confirm A11y hits `100` on home and Perf improves (bounded by the TTFB gap).
- [ ] Visual smoke on the live site: search icon still renders (`<i class="fa-solid fa-magnifying-glass">`), bars/x/chevron/GitHub/Mastodon icons still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)