### PR TITLE
fix: stop batching analytics beacons so control beacons don't drop page views

### DIFF
--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -205,6 +205,24 @@ if (
         trackHistoryChanges: false,
         trackOutboundLinks: true,
         trackFileDownloads: true,
+        // Send every beacon on its own instead of batching. This works
+        // around a tracker bug: the batch queue types every non-`pageview`
+        // send (the `consent`, `session/start` and `session/extend`
+        // heartbeat beacons — none of which are marked `immediate`) as
+        // `event`, but their payloads carry no `name`. The server's batch
+        // endpoint validates `items.*.data.name` as required for `event`
+        // items, so any batch that a control beacon lands in fails
+        // validation — a 422 that `sendBeacon` reports as success, or a 302
+        // when no `Accept: application/json` header is sent — and the whole
+        // batch, real page views included, is dropped. In practice a visit
+        // records its first page or two and then goes silent the moment the
+        // session heartbeat starts sharing the queue. Forcing batchSize 1
+        // means page views always flush alone to `/pageview` (which
+        // validates and returns 204), so none are lost. The proper fix lives
+        // in artisanpack-ui/analytics: mark those control sends `immediate`
+        // (as `session/end` already is) so they never enter the batch queue.
+        // Remove this once the app depends on a release carrying that fix.
+        batchSize: 1,
         debug: false,
     };
 

--- a/tests/Feature/AnalyticsIntegrationTest.php
+++ b/tests/Feature/AnalyticsIntegrationTest.php
@@ -130,6 +130,25 @@ it('tracks SPA navigation through exactly one tracker so views are neither lost 
         ->toContain("addEventListener('inertia:navigate'");
 });
 
+it('sends analytics beacons unbatched so control beacons cannot poison a page-view batch', function () {
+    // The vendor tracker queues its `consent`, `session/start` and
+    // `session/extend` beacons without the `immediate` flag, so they enter
+    // the batch queue typed as `event` with no `name`. The batch ingest
+    // endpoint validates `items.*.data.name` as required for `event` items,
+    // so any batch one of them shares fails validation — a 422, or a 302 when
+    // the request carries no `Accept: application/json` header, which is how
+    // `sendBeacon` sends. `sendBeacon` reports both as success, so the whole
+    // batch, real page views included, is dropped silently. A visit then
+    // records its first page or two and goes dark once the session heartbeat
+    // starts sharing the queue. batchSize 1 flushes every page view alone to
+    // `/pageview`, which validates and returns 204, so none are lost. Remove
+    // this once the app depends on an analytics release that marks those
+    // control sends `immediate`.
+    $client = (string) file_get_contents(base_path('resources/js/lib/analytics.ts'));
+
+    expect($client)->toContain('batchSize: 1');
+});
+
 it('excludes every client-side sensitive path server-side as well', function () {
     // The client keeps these URLs off the network two ways: the boot gate
     // skips the entry URL, and the guarded `inertia:navigate` bridge skips SPA


### PR DESCRIPTION
## Problem

Local analytics recorded only the first page or two of each visit, then went silent — and GA4 server-side forwarding received almost nothing (it can only forward page views the app actually records).

## Root cause

The `artisanpack-ui/analytics` client tracker queues its control-plane beacons — `consent`, `session/start`, and `session/extend` (the heartbeat) — **without** the `immediate` flag, so they land in the batch queue. `_addToQueue` types every non-`pageview` send as **`event`**, but those payloads carry no `name`. The batch ingest endpoint validates `items.*.data.name` as required for `event` items, so **any batch one of them shares fails validation** — a `422`, or a **`302` redirect** under `sendBeacon` (no `Accept: application/json` header). `sendBeacon` surfaces neither as an error, so the whole batch — real page views included — is dropped silently. Once the session heartbeat starts firing, it poisons every subsequent batch.

Verified against production:

| Payload | Result |
|---|---|
| single `/pageview` | 204 ✓ |
| batch: 2 page views | 204 ✓ |
| batch: page view + *named* event | 204 ✓ |
| batch: page view + control beacon (no name) | 422 / 302 ✗ whole batch dropped |

## Fix (this PR — app-side stopgap)

Set `batchSize: 1` in the tracker config so every page view flushes alone to `/pageview` (validates → 204) and can never share a batch with a poison control beacon.

## Proper fix (follow-up in `artisanpack-ui/analytics`)

Mark the `consent`, `session/start`, and `session/extend` sends as `immediate` (pass `true` to `Transport.send`, as `session/end` already does) so they never enter the batch queue. Optionally, make the server batch validator skip an invalid item instead of rejecting the whole batch. Once released and bumped here, remove the `batchSize: 1` workaround.

## Tests

- New assertion locking in `batchSize: 1` with the rationale.
- Full `AnalyticsIntegrationTest` suite passes (26 tests), Pint clean, bundle rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics beacon delivery by sending each control signal separately, preventing consent and session information from being combined with page-view data.

* **Tests**
  * Added coverage to verify that analytics beacons are sent individually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->