### PR TITLE
chore: adopt artisanpack-ui/analytics 1.5.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -168,16 +168,16 @@
         },
         {
             "name": "artisanpack-ui/analytics",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/analytics.git",
-                "reference": "e4b558b5a9653b905ab653ac0f888cb1c44abe77"
+                "reference": "bd1e9a9d2a3acb6d84c96581d5329995554932c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/analytics/zipball/e4b558b5a9653b905ab653ac0f888cb1c44abe77",
-                "reference": "e4b558b5a9653b905ab653ac0f888cb1c44abe77",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/analytics/zipball/bd1e9a9d2a3acb6d84c96581d5329995554932c3",
+                "reference": "bd1e9a9d2a3acb6d84c96581d5329995554932c3",
                 "shasum": ""
             },
             "require": {
@@ -251,9 +251,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/analytics/issues",
-                "source": "https://github.com/ArtisanPack-UI/analytics/tree/v1.5.0"
+                "source": "https://github.com/ArtisanPack-UI/analytics/tree/v1.5.1"
             },
-            "time": "2026-08-09T20:32:17+00:00"
+            "time": "2026-08-21T01:28:50+00:00"
         },
         {
             "name": "artisanpack-ui/analytics-google",


### PR DESCRIPTION
Bumps `artisanpack-ui/analytics` **1.5.0 → 1.5.1**.

## Why

1.5.1 fixes the ingest pipeline so page views collected by the JavaScript tracker fan out to **every** active provider, not just `local`. Until now the `google-ga4` server-side Measurement Protocol forwarder was configured, active, and enabled, yet never received a single ingested page view — the ingest path wrote only to the local provider. This release wires ingested page views to the forwarder, so GA4 finally gets real data.

Combined with the already-deployed config (`GA4_MEASUREMENT_PROTOCOL_DEBUG=false`, `google-ga4` in `ANALYTICS_ACTIVE_PROVIDERS`), forwarding goes live on merge/deploy.

## Scope

Narrow update — the lock diff is a single line: `artisanpack-ui/analytics` 1.5.0 → 1.5.1. No other dependencies moved; `artisanpack-ui/analytics-google` stays 1.1.0.

## Verification

`AnalyticsIntegrationTest` passes (26 tests). After deploy, browse a few docs pages and check GA4 → Realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)